### PR TITLE
Harden security, standardize logging, and DRY MCP clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
         run: |
           find includes -name "*.php" -exec php -l {} \;
 
-      - name: PHP CodeSniffer
-        run: composer phpcs
-
   test:
     name: PHPUnit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         run: |
           find includes -name "*.php" -exec php -l {} \;
 
+      - name: PHP CodeSniffer
+        run: composer phpcs
+
   test:
     name: PHPUnit Tests
     runs-on: ubuntu-latest

--- a/includes/Api/ApiMWAssistantChat.php
+++ b/includes/Api/ApiMWAssistantChat.php
@@ -17,6 +17,8 @@ use MWAssistant\MCP\ChatClient;
  */
 class ApiMWAssistantChat extends ApiMWAssistantBase
 {
+    private const ALLOWED_ROLES = ['user', 'assistant', 'system'];
+    private const ALLOWED_CONTEXTS = ['chat', 'editor'];
 
     /**
      * Main API execution.
@@ -55,7 +57,6 @@ class ApiMWAssistantChat extends ApiMWAssistantBase
         }
 
         // Validate each message has required fields with valid values
-        $allowedRoles = ['user', 'assistant', 'system'];
         foreach ($messages as $i => $msg) {
             if (!is_array($msg)) {
                 $this->dieWithError(
@@ -63,7 +64,7 @@ class ApiMWAssistantChat extends ApiMWAssistantBase
                     'bad-message'
                 );
             }
-            if (!isset($msg['role']) || !in_array($msg['role'], $allowedRoles, true)) {
+            if (!isset($msg['role']) || !in_array($msg['role'], self::ALLOWED_ROLES, true)) {
                 $this->dieWithError(
                     ['apierror-badparams', "Message at index $i has invalid or missing role"],
                     'bad-message-role'
@@ -78,7 +79,7 @@ class ApiMWAssistantChat extends ApiMWAssistantBase
         }
 
         // Validate context parameter
-        if (!in_array($context, ['chat', 'editor'], true)) {
+        if (!in_array($context, self::ALLOWED_CONTEXTS, true)) {
             $this->dieWithError(
                 ['apierror-badparams', 'Invalid context parameter (expected "chat" or "editor")'],
                 'bad-context'

--- a/includes/Api/ApiMWAssistantChat.php
+++ b/includes/Api/ApiMWAssistantChat.php
@@ -44,6 +44,47 @@ class ApiMWAssistantChat extends ApiMWAssistantBase
             );
         }
 
+        // Validate session_id is a valid UUID v4 if provided
+        if ($sessionId !== null && $sessionId !== '') {
+            if (!preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $sessionId)) {
+                $this->dieWithError(
+                    ['apierror-badparams', 'Invalid session_id format (expected UUID v4)'],
+                    'bad-session-id'
+                );
+            }
+        }
+
+        // Validate each message has required fields with valid values
+        $allowedRoles = ['user', 'assistant', 'system'];
+        foreach ($messages as $i => $msg) {
+            if (!is_array($msg)) {
+                $this->dieWithError(
+                    ['apierror-badparams', "Message at index $i is not an object"],
+                    'bad-message'
+                );
+            }
+            if (!isset($msg['role']) || !in_array($msg['role'], $allowedRoles, true)) {
+                $this->dieWithError(
+                    ['apierror-badparams', "Message at index $i has invalid or missing role"],
+                    'bad-message-role'
+                );
+            }
+            if (!isset($msg['content']) || !is_string($msg['content'])) {
+                $this->dieWithError(
+                    ['apierror-badparams', "Message at index $i has invalid or missing content"],
+                    'bad-message-content'
+                );
+            }
+        }
+
+        // Validate context parameter
+        if (!in_array($context, ['chat', 'editor'], true)) {
+            $this->dieWithError(
+                ['apierror-badparams', 'Invalid context parameter (expected "chat" or "editor")'],
+                'bad-context'
+            );
+        }
+
         // -------------------------------------------------------------
         // Invoke the MCP chat backend
         // -------------------------------------------------------------

--- a/includes/Api/ApiMWAssistantCheckAccess.php
+++ b/includes/Api/ApiMWAssistantCheckAccess.php
@@ -20,6 +20,9 @@ use MediaWiki\User\UserIdentity;
  */
 class ApiMWAssistantCheckAccess extends ApiMWAssistantBase
 {
+    /** @var int Maximum number of titles per batch access-check request */
+    private const MAX_TITLES_PER_REQUEST = 100;
+
     /**
      * @inheritDoc
      */
@@ -47,7 +50,7 @@ class ApiMWAssistantCheckAccess extends ApiMWAssistantBase
         }
 
         // Hard limit to prevent abuse
-        if (count($titleStrings) > 100) {
+        if (count($titleStrings) > self::MAX_TITLES_PER_REQUEST) {
             $this->dieWithError(
                 ['apierror-badparams', 'Maximum 100 titles allowed per request'],
                 'too-many-titles'

--- a/includes/Api/ApiMWAssistantCheckAccess.php
+++ b/includes/Api/ApiMWAssistantCheckAccess.php
@@ -52,7 +52,7 @@ class ApiMWAssistantCheckAccess extends ApiMWAssistantBase
         // Hard limit to prevent abuse
         if (count($titleStrings) > self::MAX_TITLES_PER_REQUEST) {
             $this->dieWithError(
-                ['apierror-badparams', 'Maximum 100 titles allowed per request'],
+                ['apierror-badparams', 'Maximum ' . self::MAX_TITLES_PER_REQUEST . ' titles allowed per request'],
                 'too-many-titles'
             );
         }

--- a/includes/Hooks/AutoEmbeddingHooks.php
+++ b/includes/Hooks/AutoEmbeddingHooks.php
@@ -71,29 +71,20 @@ class AutoEmbeddingHooks
             return;
         }
 
-        // Extract text BEFORE processing
-        $text = ContentHandler::getContentText($content);
-        if (!is_string($text) || trim($text) === '') {
-            return;
-        }
-
         // Execute immediately (synchronous) for reliability
         $client = new EmbeddingsClient();
         try {
             $res = $client->updatePage($user, $pageTitle, $text, $namespace, $timestamp);
             if (isset($res['error'])) {
-                LoggerFactory::getInstance('MWAssistant')
-                    ->error('AutoEmbed update failed for {page}: {error}', [
-                        'page' => $pageTitle,
-                        'error' => $res['message'] ?? 'Unknown error'
-                    ]);
+                $logger->error('AutoEmbed update failed for {page}: {error}', [
+                    'page' => $pageTitle,
+                    'error' => $res['message'] ?? 'Unknown error'
+                ]);
             } else {
-                LoggerFactory::getInstance('MWAssistant')
-                    ->debug('AutoEmbed success for {page}', ['page' => $pageTitle]);
+                $logger->debug('AutoEmbed success for {page}', ['page' => $pageTitle]);
             }
         } catch (\Throwable $e) {
-            LoggerFactory::getInstance('MWAssistant')
-                ->error('AutoEmbed update exception: ' . $e->getMessage());
+            $logger->error('AutoEmbed update exception: ' . $e->getMessage());
         }
     }
 
@@ -117,6 +108,7 @@ class AutoEmbeddingHooks
         $logEntry,
         bool $archived
     ): void {
+        $logger = LoggerFactory::getInstance('MWAssistant');
 
         if (!Config::isAutoEmbedEnabled()) {
             return;
@@ -138,18 +130,15 @@ class AutoEmbeddingHooks
         try {
             $res = $client->deletePage($user, $pageTitle);
             if (isset($res['error'])) {
-                LoggerFactory::getInstance('MWAssistant')
-                    ->error('AutoEmbed delete failed for {page}: {error}', [
-                        'page' => $pageTitle,
-                        'error' => $res['message'] ?? 'Unknown error'
-                    ]);
+                $logger->error('AutoEmbed delete failed for {page}: {error}', [
+                    'page' => $pageTitle,
+                    'error' => $res['message'] ?? 'Unknown error'
+                ]);
             } else {
-                LoggerFactory::getInstance('MWAssistant')
-                    ->debug('AutoEmbed delete success for {page}', ['page' => $pageTitle]);
+                $logger->debug('AutoEmbed delete success for {page}', ['page' => $pageTitle]);
             }
         } catch (\Throwable $e) {
-            LoggerFactory::getInstance('MWAssistant')
-                ->error('AutoEmbed delete error: ' . $e->getMessage());
+            $logger->error('AutoEmbed delete error: ' . $e->getMessage());
         }
     }
 }

--- a/includes/Hooks/AutoEmbeddingHooks.php
+++ b/includes/Hooks/AutoEmbeddingHooks.php
@@ -39,15 +39,16 @@ class AutoEmbeddingHooks
         RevisionRecord $revisionRecord,
         $editResult
     ): void {
+        $logger = LoggerFactory::getInstance('MWAssistant');
         if (!Config::isAutoEmbedEnabled()) {
-            error_log("[MWAssistant] AutoEmbed disabled in Config.");
+            $logger->debug('AutoEmbed disabled in Config.');
             return;
         }
-        error_log("[MWAssistant] AutoEmbed Triggered for: " . $wikiPage->getTitle()->getPrefixedText());
+        $logger->debug('AutoEmbed triggered for: {page}', ['page' => $wikiPage->getTitle()->getPrefixedText()]);
 
         $title = $wikiPage->getTitle();
         if (!$title) {
-            error_log("[MWAssistant] AutoEmbed: No title found.");
+            $logger->warning('AutoEmbed: No title found.');
             return;
         }
 

--- a/includes/Hooks/AutoEmbeddingHooks.php
+++ b/includes/Hooks/AutoEmbeddingHooks.php
@@ -39,7 +39,7 @@ class AutoEmbeddingHooks
         RevisionRecord $revisionRecord,
         $editResult
     ): void {
-        $logger = LoggerFactory::getInstance('MWAssistant');
+        $logger = LoggerFactory::getInstance('mwassistant');
         if (!Config::isAutoEmbedEnabled()) {
             $logger->debug('AutoEmbed disabled in Config.');
             return;
@@ -108,7 +108,7 @@ class AutoEmbeddingHooks
         $logEntry,
         bool $archived
     ): void {
-        $logger = LoggerFactory::getInstance('MWAssistant');
+        $logger = LoggerFactory::getInstance('mwassistant');
 
         if (!Config::isAutoEmbedEnabled()) {
             return;

--- a/includes/HttpClient.php
+++ b/includes/HttpClient.php
@@ -31,7 +31,7 @@ class HttpClient
         // Allow override (EmbeddingsClient passes explicit base).
         $this->baseUrl = rtrim($baseUrl ?? Config::getMCPBaseUrl(), '/');
         $this->factory = MediaWikiServices::getInstance()->getHttpRequestFactory();
-        $this->logger = LoggerFactory::getInstance('MWAssistant');
+        $this->logger = LoggerFactory::getInstance('mwassistant');
     }
 
     /**

--- a/includes/HttpClient.php
+++ b/includes/HttpClient.php
@@ -2,6 +2,7 @@
 
 namespace MWAssistant;
 
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Http\HttpRequestFactory;
 use StatusValue;
@@ -18,15 +19,19 @@ use StatusValue;
  */
 class HttpClient
 {
+    /** @var int Default HTTP request timeout in seconds */
+    private const REQUEST_TIMEOUT_SECONDS = 30;
 
     private string $baseUrl;
     private HttpRequestFactory $factory;
+    private \Psr\Log\LoggerInterface $logger;
 
     public function __construct(?string $baseUrl = null)
     {
         // Allow override (EmbeddingsClient passes explicit base).
         $this->baseUrl = rtrim($baseUrl ?? Config::getMCPBaseUrl(), '/');
         $this->factory = MediaWikiServices::getInstance()->getHttpRequestFactory();
+        $this->logger = LoggerFactory::getInstance('MWAssistant');
     }
 
     /**
@@ -87,7 +92,7 @@ class HttpClient
 
         $options = [
             'method' => $method,
-            'timeout' => 30,
+            'timeout' => self::REQUEST_TIMEOUT_SECONDS,
         ];
 
         if (!empty($payload)) {
@@ -111,9 +116,13 @@ class HttpClient
 
         $req = $this->factory->create($url, $options, __METHOD__);
 
+        // Generate a unique request ID for distributed tracing
+        $requestId = bin2hex(random_bytes(8));
+
         $req->setHeader('Content-Type', 'application/json');
         $req->setHeader('Authorization', 'Bearer ' . $jwt);
         $req->setHeader('User-Agent', 'MWAssistant/1.0.0 (MediaWiki)');
+        $req->setHeader('X-Request-ID', $requestId);
 
         // Transport-level execution (network/HTTP)
         $status = $req->execute();
@@ -124,10 +133,10 @@ class HttpClient
                 ? $status->getWikiText()
                 : 'Unknown HTTP transport failure';
 
-            \wfDebugLog(
-                'mwassistant',
-                "HttpClient transport error for {$url}: {$err}"
-            );
+            $this->logger->error('HttpClient transport error for {url}: {err}', [
+                'url' => $url,
+                'err' => $err,
+            ]);
 
             return [
                 'ok' => false,
@@ -146,10 +155,11 @@ class HttpClient
 
         // HTTP-level failure (non-2xx)
         if ($httpCode < 200 || $httpCode >= 300) {
-            \wfDebugLog(
-                'mwassistant',
-                "HttpClient HTTP error {$httpCode} for {$url}: {$bodyRaw}"
-            );
+            $this->logger->warning('HttpClient HTTP error {code} for {url}: {body}', [
+                'code' => $httpCode,
+                'url' => $url,
+                'body' => $bodyRaw,
+            ]);
 
             return [
                 'ok' => false,
@@ -162,10 +172,10 @@ class HttpClient
         $decoded = json_decode($bodyRaw, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            \wfDebugLog(
-                'mwassistant',
-                "HttpClient JSON decode error for {$url}: " . json_last_error_msg()
-            );
+            $this->logger->warning('HttpClient JSON decode error for {url}: {error}', [
+                'url' => $url,
+                'error' => json_last_error_msg(),
+            ]);
 
             return [
                 'ok' => false,
@@ -179,5 +189,47 @@ class HttpClient
             'code' => $httpCode,
             'body' => $decoded,
         ];
+    }
+
+    /**
+     * Normalize MCP HTTP response into a stable array format.
+     *
+     * On success: returns $resp['body']
+     * On error: returns ['error' => true, 'status' => int|null, 'message' => string]
+     *
+     * @param array $resp Raw response from request()
+     * @param string $context Context label for error messages
+     * @return array
+     */
+    public function handleResponse(array $resp, string $context = 'request'): array
+    {
+        $ok = $resp['ok'] ?? false;
+
+        if (!$ok) {
+            $code = $resp['code'] ?? null;
+            $body = $resp['body'] ?? null;
+            $bodyStr = is_string($body) ? $body : json_encode($body);
+
+            return [
+                'error' => true,
+                'status' => $code,
+                'message' => "MCP {$context} error: " . ($bodyStr ?? 'Unknown error'),
+            ];
+        }
+
+        return $resp['body'] ?? [];
+    }
+
+    /**
+     * Fetch user groups/roles for JWT construction.
+     *
+     * @param \MediaWiki\User\UserIdentity $user
+     * @return string[]
+     */
+    public static function getUserRoles(\MediaWiki\User\UserIdentity $user): array
+    {
+        return MediaWikiServices::getInstance()
+            ->getUserGroupManager()
+            ->getUserGroups($user);
     }
 }

--- a/includes/JWTVerifier.php
+++ b/includes/JWTVerifier.php
@@ -2,6 +2,7 @@
 
 namespace MWAssistant;
 
+use MediaWiki\Logger\LoggerFactory;
 use RuntimeException;
 
 /**
@@ -178,14 +179,14 @@ class JWTVerifier
 
     private function logFailure(string $reason, ?array $claims = null): void
     {
-        $entry = [
-            'reason' => $reason,
-            'timestamp' => time(),
-            'iss' => $claims['iss'] ?? null,
-            'aud' => $claims['aud'] ?? null,
-            'scopes' => $claims['scope'] ?? null,
-        ];
-
-        \wfDebugLog('mwassistant-jwt', json_encode($entry));
+        LoggerFactory::getInstance('MWAssistant')->warning(
+            'JWT verification failed: {reason}',
+            [
+                'reason' => $reason,
+                'iss' => $claims['iss'] ?? null,
+                'aud' => $claims['aud'] ?? null,
+                'scopes' => $claims['scope'] ?? null,
+            ]
+        );
     }
 }

--- a/includes/JWTVerifier.php
+++ b/includes/JWTVerifier.php
@@ -179,7 +179,7 @@ class JWTVerifier
 
     private function logFailure(string $reason, ?array $claims = null): void
     {
-        LoggerFactory::getInstance('MWAssistant')->warning(
+        LoggerFactory::getInstance('mwassistant')->warning(
             'JWT verification failed: {reason}',
             [
                 'reason' => $reason,

--- a/includes/MCP/ChatClient.php
+++ b/includes/MCP/ChatClient.php
@@ -4,7 +4,6 @@ namespace MWAssistant\MCP;
 
 use MWAssistant\HttpClient;
 use MWAssistant\JWT;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserIdentity;
 
 /**
@@ -39,7 +38,7 @@ class ChatClient
      */
     public function chat(UserIdentity $user, array $messages, ?string $sessionId = null, string $context = 'chat'): array
     {
-        $roles = $this->getUserRoles($user);
+        $roles = HttpClient::getUserRoles($user);
         $jwt = JWT::createMWToMCPToken($user, $roles, ['chat_completion']);
 
         $payload = [
@@ -52,57 +51,9 @@ class ChatClient
             $payload['session_id'] = $sessionId;
         }
 
-        \wfDebugLog('mwassistant', 'ChatClient payload: ' . json_encode($payload));
         $resp = $this->client->postJson('/chat/', $payload, $jwt);
-        \wfDebugLog('mwassistant', 'ChatClient raw response: ' . print_r($resp, true));
 
-        return $this->handleResponse($resp, 'chat');
-    }
-
-    /**
-     * Fetch user groups/roles for JWT construction.
-     *
-     * @param UserIdentity $user
-     * @return string[]
-     */
-    private function getUserRoles(UserIdentity $user): array
-    {
-        return MediaWikiServices::getInstance()
-            ->getUserGroupManager()
-            ->getUserGroups($user);
-    }
-
-    /**
-     * Normalize MCP HTTP response into a stable array format.
-     *
-     * On success:
-     *   returns $resp['body']
-     *
-     * On error:
-     *   returns ['error' => true, 'status' => int|null, 'message' => string]
-     *
-     * @param array $resp
-     * @param string $context Context label for error messages
-     * @return array
-     */
-    private function handleResponse(array $resp, string $context): array
-    {
-        $ok = $resp['ok'] ?? false;
-
-        if (!$ok) {
-            $code = $resp['code'] ?? null;
-            $body = $resp['body'] ?? null;
-
-            $bodyStr = is_string($body) ? $body : json_encode($body);
-
-            return [
-                'error' => true,
-                'status' => $code,
-                'message' => "MCP {$context} error: " . ($bodyStr ?? 'Unknown error'),
-            ];
-        }
-
-        return $resp['body'] ?? [];
+        return $this->client->handleResponse($resp, 'chat');
     }
 
     /**
@@ -115,7 +66,7 @@ class ChatClient
      */
     public function getSessions(UserIdentity $user, int $limit = 50, int $offset = 0): array
     {
-        $roles = $this->getUserRoles($user);
+        $roles = HttpClient::getUserRoles($user);
         $jwt = JWT::createMWToMCPToken($user, $roles, ['chat_completion']);
 
         $resp = $this->client->getJson('/chat/sessions', [
@@ -123,7 +74,7 @@ class ChatClient
             'offset' => $offset,
         ], $jwt);
 
-        return $this->handleResponse($resp, 'list sessions');
+        return $this->client->handleResponse($resp, 'list sessions');
     }
 
     /**
@@ -135,12 +86,12 @@ class ChatClient
      */
     public function getSession(UserIdentity $user, string $sessionId): array
     {
-        $roles = $this->getUserRoles($user);
+        $roles = HttpClient::getUserRoles($user);
         $jwt = JWT::createMWToMCPToken($user, $roles, ['chat_completion']);
 
         $resp = $this->client->getJson("/chat/sessions/{$sessionId}", [], $jwt);
 
-        return $this->handleResponse($resp, 'get session');
+        return $this->client->handleResponse($resp, 'get session');
     }
 
     /**
@@ -152,12 +103,11 @@ class ChatClient
      */
     public function deleteSession(UserIdentity $user, string $sessionId): array
     {
-        $roles = $this->getUserRoles($user);
+        $roles = HttpClient::getUserRoles($user);
         $jwt = JWT::createMWToMCPToken($user, $roles, ['chat_completion']);
 
         $resp = $this->client->delete("/chat/sessions/{$sessionId}", $jwt);
 
-        return $this->handleResponse($resp, 'delete session');
+        return $this->client->handleResponse($resp, 'delete session');
     }
 }
-

--- a/includes/MCP/EmbeddingsClient.php
+++ b/includes/MCP/EmbeddingsClient.php
@@ -5,7 +5,6 @@ namespace MWAssistant\MCP;
 use MWAssistant\Config;
 use MWAssistant\HttpClient;
 use MWAssistant\JWT;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserIdentity;
 
 /**
@@ -34,6 +33,7 @@ class EmbeddingsClient
      * @param UserIdentity $user
      * @param string $title
      * @param string $content
+     * @param int $namespace
      * @param string|null $timestamp Last-modified timestamp (optional)
      *
      * @return array
@@ -55,14 +55,11 @@ class EmbeddingsClient
         ];
 
         $resp = $this->client->postJson('/embeddings/page', $payload, $jwt);
-        return $this->handleResponse($resp);
+        return $this->client->handleResponse($resp, 'embeddings update');
     }
 
     /**
      * Delete embeddings for a given page title.
-     *
-     * Assumes MCP server exposes:
-     *   DELETE /embeddings/page    with JSON body { "title": "<title>" }
      *
      * @param UserIdentity $user
      * @param string $title
@@ -75,9 +72,8 @@ class EmbeddingsClient
 
         $payload = ['title' => $title];
 
-        // Assumes HttpClient::request(method, path, payload, jwt) is supported.
         $resp = $this->client->request('DELETE', '/embeddings/page', $payload, $jwt);
-        return $this->handleResponse($resp);
+        return $this->client->handleResponse($resp, 'embeddings delete');
     }
 
     /**
@@ -90,7 +86,7 @@ class EmbeddingsClient
     {
         $jwt = $this->createToken($user);
         $resp = $this->client->getJson('/embeddings/stats', [], $jwt);
-        return $this->handleResponse($resp);
+        return $this->client->handleResponse($resp, 'embeddings stats');
     }
 
     /**
@@ -101,41 +97,7 @@ class EmbeddingsClient
      */
     private function createToken(UserIdentity $user): string
     {
-        $roles = MediaWikiServices::getInstance()
-            ->getUserGroupManager()
-            ->getUserGroups($user);
-
+        $roles = HttpClient::getUserRoles($user);
         return JWT::createMWToMCPToken($user, $roles, ['embeddings']);
-    }
-
-    /**
-     * Normalize MCP HTTP response into a consistent shape.
-     *
-     * On success:
-     *  - returns $resp['body'] (or [] if missing)
-     *
-     * On error:
-     *  - returns ['error' => true, 'status' => int|null, 'message' => string]
-     *
-     * @param array $resp
-     * @return array
-     */
-    private function handleResponse(array $resp): array
-    {
-        $ok = $resp['ok'] ?? false;
-
-        if (!$ok) {
-            $code = $resp['code'] ?? null;
-            $body = $resp['body'] ?? null;
-            $bodyStr = is_string($body) ? $body : json_encode($body);
-
-            return [
-                'error' => true,
-                'status' => $code,
-                'message' => 'MCP embeddings error: ' . ($bodyStr ?? 'Unknown error'),
-            ];
-        }
-
-        return $resp['body'] ?? [];
     }
 }

--- a/includes/MCP/SMWClient.php
+++ b/includes/MCP/SMWClient.php
@@ -4,7 +4,6 @@ namespace MWAssistant\MCP;
 
 use MWAssistant\HttpClient;
 use MWAssistant\JWT;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserIdentity;
 
 /**
@@ -39,7 +38,7 @@ class SMWClient
      */
     public function query(UserIdentity $user, string $description): array
     {
-        $roles = $this->getUserRoles($user);
+        $roles = HttpClient::getUserRoles($user);
         $jwt = JWT::createMWToMCPToken($user, $roles, ['smw_query']);
 
         $payload = [
@@ -48,45 +47,6 @@ class SMWClient
         ];
 
         $resp = $this->client->postJson('/smw-query/', $payload, $jwt);
-        return $this->handleResponse($resp, 'SMW query');
-    }
-
-    /**
-     * Fetch user groups/roles for JWT construction.
-     *
-     * @param UserIdentity $user
-     * @return string[]
-     */
-    private function getUserRoles(UserIdentity $user): array
-    {
-        return MediaWikiServices::getInstance()
-            ->getUserGroupManager()
-            ->getUserGroups($user);
-    }
-
-    /**
-     * Normalize MCP HTTP response into a stable array format.
-     *
-     * @param array $resp
-     * @param string $context
-     * @return array
-     */
-    private function handleResponse(array $resp, string $context): array
-    {
-        $ok = $resp['ok'] ?? false;
-
-        if (!$ok) {
-            $code = $resp['code'] ?? null;
-            $body = $resp['body'] ?? null;
-            $bodyStr = is_string($body) ? $body : json_encode($body);
-
-            return [
-                'error' => true,
-                'status' => $code,
-                'message' => "MCP {$context} error: " . ($bodyStr ?? 'Unknown error'),
-            ];
-        }
-
-        return $resp['body'] ?? [];
+        return $this->client->handleResponse($resp, 'SMW query');
     }
 }

--- a/includes/MCP/VectorSearchClient.php
+++ b/includes/MCP/VectorSearchClient.php
@@ -4,7 +4,6 @@ namespace MWAssistant\MCP;
 
 use MWAssistant\HttpClient;
 use MWAssistant\JWT;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserIdentity;
 
 /**
@@ -35,7 +34,7 @@ class VectorSearchClient
      */
     public function search(UserIdentity $user, string $query): array
     {
-        $roles = $this->getUserRoles($user);
+        $roles = HttpClient::getUserRoles($user);
         $jwt = JWT::createMWToMCPToken($user, $roles, ['search']);
 
         $payload = [
@@ -43,45 +42,6 @@ class VectorSearchClient
         ];
 
         $resp = $this->client->postJson('/search/', $payload, $jwt);
-        return $this->handleResponse($resp, 'search');
-    }
-
-    /**
-     * Fetch user groups/roles for JWT construction.
-     *
-     * @param UserIdentity $user
-     * @return string[]
-     */
-    private function getUserRoles(UserIdentity $user): array
-    {
-        return MediaWikiServices::getInstance()
-            ->getUserGroupManager()
-            ->getUserGroups($user);
-    }
-
-    /**
-     * Normalize MCP HTTP response into a stable array format.
-     *
-     * @param array $resp
-     * @param string $context
-     * @return array
-     */
-    private function handleResponse(array $resp, string $context): array
-    {
-        $ok = $resp['ok'] ?? false;
-
-        if (!$ok) {
-            $code = $resp['code'] ?? null;
-            $body = $resp['body'] ?? null;
-            $bodyStr = is_string($body) ? $body : json_encode($body);
-
-            return [
-                'error' => true,
-                'status' => $code,
-                'message' => "MCP {$context} error: " . ($bodyStr ?? 'Unknown error'),
-            ];
-        }
-
-        return $resp['body'] ?? [];
+        return $this->client->handleResponse($resp, 'search');
     }
 }

--- a/includes/SMW/SMWParserEvaluator.php
+++ b/includes/SMW/SMWParserEvaluator.php
@@ -22,10 +22,19 @@ class SMWParserEvaluator
      * @param string $queryArgs The inner arguments for #ask (e.g. "[[Cat:X]]|?Prop")
      * @return ParserOutput The full parser output (use getText() for HTML, getLinks() for subjects)
      */
+    /** @var int Default limit for SMW query results */
+    private const SMW_RESULT_LIMIT = 100;
+
     public function evaluate(UserIdentity $user, string $queryArgs): ParserOutput
     {
+        // Append a result limit if the query doesn't already specify one
+        $trimmed = trim($queryArgs);
+        if (!preg_match('/\|limit\s*=/i', $trimmed)) {
+            $trimmed .= '|limit=' . self::SMW_RESULT_LIMIT;
+        }
+
         // Construct the full parser function
-        $wikitext = "{{#ask:" . trim($queryArgs) . "}}";
+        $wikitext = "{{#ask:" . $trimmed . "}}";
 
         // Parse it using the standard MediaWiki parser
         $parser = MediaWikiServices::getInstance()->getParser();

--- a/includes/SMW/SMWParserEvaluator.php
+++ b/includes/SMW/SMWParserEvaluator.php
@@ -14,6 +14,9 @@ use MediaWiki\User\UserIdentity;
  */
 class SMWParserEvaluator
 {
+    /** @var int Default limit for SMW query results */
+    private const SMW_RESULT_LIMIT = 100;
+
     /**
      * Evaluate an SMW query string by wrapping it in {{#ask:...}}
      * and parsing it.
@@ -22,9 +25,6 @@ class SMWParserEvaluator
      * @param string $queryArgs The inner arguments for #ask (e.g. "[[Cat:X]]|?Prop")
      * @return ParserOutput The full parser output (use getText() for HTML, getLinks() for subjects)
      */
-    /** @var int Default limit for SMW query results */
-    private const SMW_RESULT_LIMIT = 100;
-
     public function evaluate(UserIdentity $user, string $queryArgs): ParserOutput
     {
         // Append a result limit if the query doesn't already specify one

--- a/includes/Special/SpecialMWAssistantEmbeddings.php
+++ b/includes/Special/SpecialMWAssistantEmbeddings.php
@@ -145,7 +145,7 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
                 "Updated: <b>$updated</b><br>" .
                 "Skipped: $skipped<br>" .
                 "Errors: $errors" .
-                ($errors && $lastErr ? "<br>Last Error: $lastErr" : "");
+                ($errors && $lastErr ? "<br>Last Error: " . htmlspecialchars($lastErr) : "");
 
             $output->addHTML(Html::successBox($msg));
 
@@ -195,7 +195,7 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
         );
 
         if (isset($res['error'])) {
-            $output->addHTML(Html::errorBox($res['message']));
+            $output->addHTML(Html::errorBox(htmlspecialchars($res['message'] ?? 'Unknown error')));
         } else {
             $output->addHTML(
                 Html::successBox(

--- a/resources/mwassistant.chat.js
+++ b/resources/mwassistant.chat.js
@@ -143,16 +143,21 @@
                 return;
             }
 
-            const items = this.sessions.map(s => `
-                <div class="mwassistant-session-item ${s.session_id === this.sessionId ? 'active' : ''}" 
-                     data-session-id="${s.session_id}">
+            const items = this.sessions.map(s => {
+                const safeId = this.escapeHtml(s.session_id || '');
+                const safeTitle = this.escapeHtml(s.title || 'Untitled');
+                const safeDate = this.escapeHtml(formatDate(s.updated_at));
+                const activeClass = s.session_id === this.sessionId ? 'active' : '';
+                return `
+                <div class="mwassistant-session-item ${activeClass}"
+                     data-session-id="${safeId}">
                     <div class="mwassistant-session-info">
-                        <span class="mwassistant-session-title">${this.escapeHtml(s.title || 'Untitled')}</span>
-                        <span class="mwassistant-session-date">${formatDate(s.updated_at)}</span>
+                        <span class="mwassistant-session-title">${safeTitle}</span>
+                        <span class="mwassistant-session-date">${safeDate}</span>
                     </div>
-                    <button class="mwassistant-session-delete" data-session-id="${s.session_id}" title="Delete">×</button>
-                </div>
-            `).join('');
+                    <button class="mwassistant-session-delete" data-session-id="${safeId}" title="Delete">×</button>
+                </div>`;
+            }).join('');
 
             $list.html(items);
         }


### PR DESCRIPTION
## Summary

- **Security**: Fix XSS in embeddings page error messages and JS session list, add input validation (UUID session_id, message role/content, context param), append default SMW query limit
- **Maintainability**: Standardize all logging on `LoggerFactory`, extract shared `handleResponse()`/`getUserRoles()` into `HttpClient`, replace magic numbers with named constants, add `X-Request-ID` header for distributed tracing
- **CI**: Add `composer phpcs` lint step to workflow

### Changes by file

| File | Changes |
|------|---------|
| `SpecialMWAssistantEmbeddings.php` | Escape `$lastErr` and `$res['message']` with `htmlspecialchars()` |
| `mwassistant.chat.js` | Escape all session data in template strings via `escapeHtml()` |
| `ApiMWAssistantChat.php` | UUID v4 regex on session_id, validate message role/content, validate context |
| `SMWParserEvaluator.php` | Auto-append `\|limit=100` if query has no limit |
| `AutoEmbeddingHooks.php` | Replace `error_log()` with `LoggerFactory` |
| `HttpClient.php` | Replace `wfDebugLog` with `LoggerFactory`, add shared `handleResponse()`/`getUserRoles()`, add `X-Request-ID` header, extract `REQUEST_TIMEOUT_SECONDS` constant |
| `JWTVerifier.php` | Replace `wfDebugLog` with `LoggerFactory` |
| `ChatClient.php` | Use shared `HttpClient::handleResponse()`/`getUserRoles()`, remove debug payload logging |
| `VectorSearchClient.php` | Use shared methods, remove duplicate code |
| `SMWClient.php` | Use shared methods, remove duplicate code |
| `EmbeddingsClient.php` | Use shared methods, remove duplicate code |
| `ApiMWAssistantCheckAccess.php` | Extract `MAX_TITLES_PER_REQUEST` constant |
| `ci.yml` | Add phpcs lint step |

## Companion PR

labki-org/mw-mcp-server — corresponding security/maintainability improvements

## Test plan

- [ ] PHP syntax check passes (`find includes -name "*.php" -exec php -l {} \;`)
- [ ] CI pipeline passes (syntax + phpcs + PHPUnit)
- [ ] Batch embeddings update displays escaped error messages correctly
- [ ] Chat sessions work end-to-end with new validation
- [ ] Invalid session_id / context / messages rejected with proper error

🤖 Generated with [Claude Code](https://claude.com/claude-code)