### PR TITLE
Stream tool steps to chat UI as they happen

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -103,6 +103,9 @@
         },
         "MWAssistantEmbeddings": {
             "class": "MWAssistant\\Special\\SpecialMWAssistantEmbeddings"
+        },
+        "MWAssistantStream": {
+            "class": "MWAssistant\\Special\\SpecialMWAssistantStream"
         }
     },
     "Hooks": {

--- a/includes/Api/ApiMWAssistantChat.php
+++ b/includes/Api/ApiMWAssistantChat.php
@@ -2,6 +2,7 @@
 
 namespace MWAssistant\Api;
 
+use MWAssistant\Chat\ChatRequestValidator;
 use MWAssistant\MCP\ChatClient;
 
 /**
@@ -17,85 +18,31 @@ use MWAssistant\MCP\ChatClient;
  */
 class ApiMWAssistantChat extends ApiMWAssistantBase
 {
-    private const ALLOWED_ROLES = ['user', 'assistant', 'system'];
-    private const ALLOWED_CONTEXTS = ['chat', 'editor'];
-
-    /**
-     * Main API execution.
-     *
-     * @return void
-     */
     public function execute(): void
     {
-        // Require the JWT scope "chat_completion" if authenticated via JWT.
         $this->checkAccess(['chat_completion']);
 
         $params = $this->extractRequestParams();
 
-        // -------------------------------------------------------------
-        // Parameter validation
-        // -------------------------------------------------------------
         $messages = json_decode($params['messages'], true);
         $sessionId = $params['session_id'] ?? null;
         $context = $params['context'] ?? 'chat';
 
-        if (!is_array($messages)) {
-            $this->dieWithError(
-                ['apierror-badparams', 'Invalid messages parameter'],
-                'messages'
-            );
+        $err = ChatRequestValidator::validateMessages($messages);
+        if ($err === null) {
+            $err = ChatRequestValidator::validateSessionId($sessionId);
+        }
+        if ($err === null) {
+            $err = ChatRequestValidator::validateContext($context);
+        }
+        if ($err !== null) {
+            $this->dieWithError(['apierror-badparams', $err[1]], $err[0]);
         }
 
-        // Validate session_id is a valid UUID v4 if provided
-        if ($sessionId !== null && $sessionId !== '') {
-            if (!preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $sessionId)) {
-                $this->dieWithError(
-                    ['apierror-badparams', 'Invalid session_id format (expected UUID v4)'],
-                    'bad-session-id'
-                );
-            }
-        }
-
-        // Validate each message has required fields with valid values
-        foreach ($messages as $i => $msg) {
-            if (!is_array($msg)) {
-                $this->dieWithError(
-                    ['apierror-badparams', "Message at index $i is not an object"],
-                    'bad-message'
-                );
-            }
-            if (!isset($msg['role']) || !in_array($msg['role'], self::ALLOWED_ROLES, true)) {
-                $this->dieWithError(
-                    ['apierror-badparams', "Message at index $i has invalid or missing role"],
-                    'bad-message-role'
-                );
-            }
-            if (!isset($msg['content']) || !is_string($msg['content'])) {
-                $this->dieWithError(
-                    ['apierror-badparams', "Message at index $i has invalid or missing content"],
-                    'bad-message-content'
-                );
-            }
-        }
-
-        // Validate context parameter
-        if (!in_array($context, self::ALLOWED_CONTEXTS, true)) {
-            $this->dieWithError(
-                ['apierror-badparams', 'Invalid context parameter (expected "chat" or "editor")'],
-                'bad-context'
-            );
-        }
-
-        // -------------------------------------------------------------
-        // Invoke the MCP chat backend
-        // -------------------------------------------------------------
         $user = $this->resolveUser();
         $client = new ChatClient();
         $response = $client->chat($user, $messages, $sessionId, $context);
 
-        // -------------------------------------------------------------
-        // Output result
-        // -------------------------------------------------------------
         $this->getResult()->addValue(
             null,
             $this->getModuleName(),
@@ -126,8 +73,6 @@ class ApiMWAssistantChat extends ApiMWAssistantBase
 
     /**
      * Chat actions require a CSRF token when invoked from the UI.
-     *
-     * @return string
      */
     public function needsToken(): string
     {

--- a/includes/Chat/ChatRequestValidator.php
+++ b/includes/Chat/ChatRequestValidator.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace MWAssistant\Chat;
+
+/**
+ * Validates the shape of a chat request payload (messages array, optional
+ * session id, context). Both the buffered API endpoint and the streaming
+ * Special page accept the same shape, so the validation lives here in one
+ * place rather than being duplicated.
+ *
+ * Each validator returns null on success, or an [errorCode, errorMessage]
+ * pair on failure. Callers translate that into whichever error mechanism
+ * suits them (ApiBase::dieWithError vs. SpecialPage JSON response).
+ */
+class ChatRequestValidator
+{
+    public const ALLOWED_ROLES = ['user', 'assistant', 'system'];
+    public const ALLOWED_CONTEXTS = ['chat', 'editor'];
+
+    private const UUID_V4 = '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
+
+    /**
+     * Validate that $messages is a non-empty array of {role, content} entries
+     * with allowed roles and string content.
+     *
+     * @param mixed $messages Raw decoded value
+     * @return array{0:string,1:string}|null [errorCode, message] on failure, null on success
+     */
+    public static function validateMessages($messages, bool $requireNonEmpty = false): ?array
+    {
+        if (!is_array($messages)) {
+            return ['messages', 'Invalid messages parameter'];
+        }
+        if ($requireNonEmpty && empty($messages)) {
+            return ['bad_messages', 'messages must be a non-empty array.'];
+        }
+        foreach ($messages as $i => $msg) {
+            if (!is_array($msg)) {
+                return ['bad-message', "Message at index {$i} is not an object"];
+            }
+            if (!isset($msg['role']) || !in_array($msg['role'], self::ALLOWED_ROLES, true)) {
+                return ['bad-message-role', "Message at index {$i} has invalid or missing role"];
+            }
+            if (!isset($msg['content']) || !is_string($msg['content'])) {
+                return ['bad-message-content', "Message at index {$i} has invalid or missing content"];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Validate context parameter (optional; null/empty defaults to "chat").
+     *
+     * @param mixed $context
+     * @return array{0:string,1:string}|null
+     */
+    public static function validateContext($context): ?array
+    {
+        if (!in_array($context, self::ALLOWED_CONTEXTS, true)) {
+            return ['bad-context', 'Invalid context parameter (expected "chat" or "editor")'];
+        }
+        return null;
+    }
+
+    /**
+     * Validate optional session_id is a UUID v4.
+     *
+     * @param mixed $sessionId Null, empty string, or candidate UUID
+     * @return array{0:string,1:string}|null
+     */
+    public static function validateSessionId($sessionId): ?array
+    {
+        if ($sessionId === null || $sessionId === '') {
+            return null;
+        }
+        if (!is_string($sessionId) || !preg_match(self::UUID_V4, $sessionId)) {
+            return ['bad-session-id', 'Invalid session_id format (expected UUID v4)'];
+        }
+        return null;
+    }
+}

--- a/includes/Special/SpecialMWAssistantStream.php
+++ b/includes/Special/SpecialMWAssistantStream.php
@@ -4,6 +4,7 @@ namespace MWAssistant\Special;
 
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\SpecialPage\UnlistedSpecialPage;
+use MWAssistant\Chat\ChatRequestValidator;
 use MWAssistant\Config;
 use MWAssistant\HttpClient;
 use MWAssistant\JWT;
@@ -25,8 +26,6 @@ use Throwable;
  */
 class SpecialMWAssistantStream extends UnlistedSpecialPage
 {
-    private const ALLOWED_ROLES = ['user', 'assistant', 'system'];
-    private const ALLOWED_CONTEXTS = ['chat', 'editor'];
     private const STREAM_TIMEOUT_SECONDS = 300;
 
     public function __construct()
@@ -73,30 +72,16 @@ class SpecialMWAssistantStream extends UnlistedSpecialPage
         $sessionId = $payload['session_id'] ?? null;
         $context = $payload['context'] ?? 'chat';
 
-        if (!is_array($messages) || empty($messages)) {
-            $this->writeErrorAndExit(400, 'bad_messages', 'messages must be a non-empty array.');
+        $err = ChatRequestValidator::validateMessages($messages, true);
+        if ($err === null) {
+            $err = ChatRequestValidator::validateContext($context);
+        }
+        if ($err === null) {
+            $err = ChatRequestValidator::validateSessionId($sessionId);
+        }
+        if ($err !== null) {
+            $this->writeErrorAndExit(400, $err[0], $err[1]);
             return;
-        }
-        if (!in_array($context, self::ALLOWED_CONTEXTS, true)) {
-            $this->writeErrorAndExit(400, 'bad_context', 'context must be "chat" or "editor".');
-            return;
-        }
-        if ($sessionId !== null && $sessionId !== '') {
-            if (!preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $sessionId)) {
-                $this->writeErrorAndExit(400, 'bad_session_id', 'session_id must be a UUID v4.');
-                return;
-            }
-        }
-        foreach ($messages as $i => $msg) {
-            if (!is_array($msg)
-                || !isset($msg['role'])
-                || !in_array($msg['role'], self::ALLOWED_ROLES, true)
-                || !isset($msg['content'])
-                || !is_string($msg['content'])
-            ) {
-                $this->writeErrorAndExit(400, 'bad_message', "Message at index {$i} is malformed.");
-                return;
-            }
         }
 
         $upstream = [
@@ -150,12 +135,10 @@ class SpecialMWAssistantStream extends UnlistedSpecialPage
         // with ":") are ignored by clients but force any FastCGI / mod_proxy
         // buffer to flush, since the default Apache FastCGI buffer is ~4 KB.
         echo ':' . str_repeat(' ', 4096) . "\n\n";
-        $this->flushAllBuffers();
+        @flush();
 
-        // Fire a heartbeat so the JS client can confirm the stream is alive
-        // even before the LLM produces its first token.
         echo "event: heartbeat\ndata: {\"ts\":" . time() . "}\n\n";
-        $this->flushAllBuffers();
+        @flush();
 
         $url = Config::getMCPBaseUrl() . '/chat/stream';
         $body = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
@@ -164,39 +147,41 @@ class SpecialMWAssistantStream extends UnlistedSpecialPage
         }
 
         $ch = curl_init();
-        curl_setopt_array($ch, [
-            CURLOPT_URL => $url,
-            CURLOPT_POST => true,
-            CURLOPT_POSTFIELDS => $body,
-            CURLOPT_HTTPHEADER => [
-                'Authorization: Bearer ' . $jwt,
-                'Content-Type: application/json',
-                'Accept: text/event-stream',
-                'User-Agent: MWAssistant/1.0.0 (MediaWiki streaming proxy)',
-                'X-Request-ID: ' . bin2hex(random_bytes(8)),
-            ],
-            CURLOPT_TIMEOUT => self::STREAM_TIMEOUT_SECONDS,
-            CURLOPT_CONNECTTIMEOUT => 10,
-            CURLOPT_RETURNTRANSFER => false,
-            CURLOPT_HEADER => false,
-            CURLOPT_BUFFERSIZE => 256,
-            CURLOPT_TCP_NODELAY => true,
-            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-            CURLOPT_WRITEFUNCTION => function ($ch, $chunk) {
-                if (connection_aborted()) {
-                    return -1;
-                }
-                echo $chunk;
-                $this->flushAllBuffers();
-                return strlen($chunk);
-            },
-        ]);
+        try {
+            curl_setopt_array($ch, [
+                CURLOPT_URL => $url,
+                CURLOPT_POST => true,
+                CURLOPT_POSTFIELDS => $body,
+                CURLOPT_HTTPHEADER => [
+                    'Authorization: Bearer ' . $jwt,
+                    'Content-Type: application/json',
+                    'Accept: text/event-stream',
+                    'User-Agent: MWAssistant/1.0.0 (MediaWiki streaming proxy)',
+                    'X-Request-ID: ' . bin2hex(random_bytes(8)),
+                ],
+                CURLOPT_TIMEOUT => self::STREAM_TIMEOUT_SECONDS,
+                CURLOPT_CONNECTTIMEOUT => 10,
+                CURLOPT_RETURNTRANSFER => false,
+                CURLOPT_HEADER => false,
+                CURLOPT_TCP_NODELAY => true,
+                CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+                CURLOPT_WRITEFUNCTION => function ($ch, $chunk) {
+                    if (connection_aborted()) {
+                        return -1;
+                    }
+                    echo $chunk;
+                    @flush();
+                    return strlen($chunk);
+                },
+            ]);
 
-        $ok = curl_exec($ch);
-        $errno = curl_errno($ch);
-        $errstr = curl_error($ch);
-        $httpCode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
+            $ok = curl_exec($ch);
+            $errno = curl_errno($ch);
+            $errstr = curl_error($ch);
+            $httpCode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        } finally {
+            curl_close($ch);
+        }
 
         if (!$ok && !connection_aborted()) {
             $logger = LoggerFactory::getInstance(Config::LOGGER_CHANNEL);
@@ -241,12 +226,12 @@ class SpecialMWAssistantStream extends UnlistedSpecialPage
      */
     private function disableAllBuffering(): void
     {
-        // MediaWiki's helper drains every buffer level it can find.
         if (function_exists('wfResetOutputBuffers')) {
             wfResetOutputBuffers();
-        }
-        while (ob_get_level() > 0) {
-            @ob_end_flush();
+        } else {
+            while (ob_get_level() > 0) {
+                @ob_end_flush();
+            }
         }
 
         @ini_set('zlib.output_compression', '0');
@@ -261,14 +246,4 @@ class SpecialMWAssistantStream extends UnlistedSpecialPage
         }
     }
 
-    /**
-     * Flush every buffer layer that's still active. Cheap to call repeatedly.
-     */
-    private function flushAllBuffers(): void
-    {
-        while (ob_get_level() > 0) {
-            @ob_flush();
-        }
-        @flush();
-    }
 }

--- a/includes/Special/SpecialMWAssistantStream.php
+++ b/includes/Special/SpecialMWAssistantStream.php
@@ -136,16 +136,26 @@ class SpecialMWAssistantStream extends UnlistedSpecialPage
      */
     private function streamSse(array $payload, string $jwt): void
     {
+        $this->disableAllBuffering();
+
         header('Content-Type: text/event-stream; charset=utf-8');
         header('Cache-Control: no-cache, no-store, must-revalidate');
         header('Pragma: no-cache');
         header('X-Accel-Buffering: no');
         header('Connection: keep-alive');
+        header('Content-Encoding: identity');
+        header_remove('Content-Length');
 
-        while (ob_get_level() > 0) {
-            @ob_end_flush();
-        }
-        @ob_implicit_flush(true);
+        // Emit a 4 KB SSE comment immediately. SSE comments (lines beginning
+        // with ":") are ignored by clients but force any FastCGI / mod_proxy
+        // buffer to flush, since the default Apache FastCGI buffer is ~4 KB.
+        echo ':' . str_repeat(' ', 4096) . "\n\n";
+        $this->flushAllBuffers();
+
+        // Fire a heartbeat so the JS client can confirm the stream is alive
+        // even before the LLM produces its first token.
+        echo "event: heartbeat\ndata: {\"ts\":" . time() . "}\n\n";
+        $this->flushAllBuffers();
 
         $url = Config::getMCPBaseUrl() . '/chat/stream';
         $body = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
@@ -177,7 +187,7 @@ class SpecialMWAssistantStream extends UnlistedSpecialPage
                     return -1;
                 }
                 echo $chunk;
-                @flush();
+                $this->flushAllBuffers();
                 return strlen($chunk);
             },
         ]);
@@ -211,5 +221,54 @@ class SpecialMWAssistantStream extends UnlistedSpecialPage
         http_response_code($httpCode);
         header('Content-Type: application/json');
         echo json_encode(['error' => $code, 'message' => $message]);
+    }
+
+    /**
+     * Defense-in-depth: disable every layer of output buffering / compression
+     * we know about so each echo + flush() actually reaches the client.
+     *
+     * Stacks we have to defeat, from innermost to outermost:
+     *   1. PHP user-level ob_start() buffers (incl. MW's own).
+     *   2. PHP zlib.output_compression (gzip in the engine).
+     *   3. PHP output_handler / output_buffering ini directives.
+     *   4. Apache mod_deflate (when DEFLATE filter is active).
+     *   5. mod_proxy_fcgi default 8 KB write buffer (php-fpm setups).
+     *
+     * Layers 4 + 5 also need server-side config (mod_deflate exclusion,
+     * `flushpackets=on` on ProxyPass) — see deploy notes — but the
+     * `apache_setenv('no-gzip')` hint plus the 4 KB SSE warmup comment
+     * cover the common defaults.
+     */
+    private function disableAllBuffering(): void
+    {
+        // MediaWiki's helper drains every buffer level it can find.
+        if (function_exists('wfResetOutputBuffers')) {
+            wfResetOutputBuffers();
+        }
+        while (ob_get_level() > 0) {
+            @ob_end_flush();
+        }
+
+        @ini_set('zlib.output_compression', '0');
+        @ini_set('output_buffering', '0');
+        @ini_set('implicit_flush', '1');
+        @ob_implicit_flush(true);
+
+        // Apache mod_deflate / mod_gzip respect these per-request hints.
+        if (function_exists('apache_setenv')) {
+            @apache_setenv('no-gzip', '1');
+            @apache_setenv('dont-vary', '1');
+        }
+    }
+
+    /**
+     * Flush every buffer layer that's still active. Cheap to call repeatedly.
+     */
+    private function flushAllBuffers(): void
+    {
+        while (ob_get_level() > 0) {
+            @ob_flush();
+        }
+        @flush();
     }
 }

--- a/includes/Special/SpecialMWAssistantStream.php
+++ b/includes/Special/SpecialMWAssistantStream.php
@@ -61,6 +61,18 @@ class SpecialMWAssistantStream extends UnlistedSpecialPage
             return;
         }
 
+        // Long-running stream: don't let PHP's max_execution_time kill us
+        // mid-tool-loop. cURL has its own STREAM_TIMEOUT_SECONDS guard.
+        @set_time_limit(0);
+
+        // Release the PHP session lock immediately so the same user can keep
+        // navigating the wiki while their chat streams. Without this, any
+        // other request from the same user blocks until execute() returns,
+        // which can be 30+ seconds for a multi-tool query.
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            @session_write_close();
+        }
+
         $rawBody = file_get_contents('php://input');
         $payload = json_decode($rawBody, true);
         if (!is_array($payload)) {

--- a/includes/Special/SpecialMWAssistantStream.php
+++ b/includes/Special/SpecialMWAssistantStream.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace MWAssistant\Special;
+
+use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\SpecialPage\UnlistedSpecialPage;
+use MWAssistant\Config;
+use MWAssistant\HttpClient;
+use MWAssistant\JWT;
+use Throwable;
+
+/**
+ * Streaming proxy for the MCP server's POST /chat/stream endpoint.
+ *
+ * MediaWiki's API framework buffers responses through ApiResult and is
+ * unsuitable for Server-Sent Events. This special page bypasses that
+ * pipeline: it disables the standard output, mints a short-lived MW->MCP
+ * JWT, opens a streaming cURL connection to /chat/stream, and forwards
+ * raw event bytes to the browser as they arrive.
+ *
+ * The JS chat UI hits this endpoint via fetch() + ReadableStream so the
+ * Authorization header (held server-side here) doesn't need to be visible
+ * to the browser, and so each tool_start / tool_result / assistant_message
+ * SSE frame can be rendered as it is produced.
+ */
+class SpecialMWAssistantStream extends UnlistedSpecialPage
+{
+    private const ALLOWED_ROLES = ['user', 'assistant', 'system'];
+    private const ALLOWED_CONTEXTS = ['chat', 'editor'];
+    private const STREAM_TIMEOUT_SECONDS = 300;
+
+    public function __construct()
+    {
+        parent::__construct('MWAssistantStream', 'mwassistant-use');
+    }
+
+    /**
+     * @param string|null $par
+     */
+    public function execute($par)
+    {
+        $request = $this->getRequest();
+        $user = $this->getUser();
+        $logger = LoggerFactory::getInstance(Config::LOGGER_CHANNEL);
+
+        $out = $this->getOutput();
+        $out->disable();
+
+        if (!$user->isAllowed('mwassistant-use')) {
+            $this->writeErrorAndExit(403, 'permission_denied', 'You do not have permission to use MWAssistant.');
+            return;
+        }
+
+        if (!$request->wasPosted()) {
+            $this->writeErrorAndExit(405, 'method_not_allowed', 'POST required.');
+            return;
+        }
+
+        $token = $request->getVal('token', '');
+        if (!$user->matchEditToken($token)) {
+            $this->writeErrorAndExit(403, 'bad_token', 'Invalid CSRF token.');
+            return;
+        }
+
+        $rawBody = file_get_contents('php://input');
+        $payload = json_decode($rawBody, true);
+        if (!is_array($payload)) {
+            $this->writeErrorAndExit(400, 'bad_json', 'Request body must be JSON.');
+            return;
+        }
+
+        $messages = $payload['messages'] ?? null;
+        $sessionId = $payload['session_id'] ?? null;
+        $context = $payload['context'] ?? 'chat';
+
+        if (!is_array($messages) || empty($messages)) {
+            $this->writeErrorAndExit(400, 'bad_messages', 'messages must be a non-empty array.');
+            return;
+        }
+        if (!in_array($context, self::ALLOWED_CONTEXTS, true)) {
+            $this->writeErrorAndExit(400, 'bad_context', 'context must be "chat" or "editor".');
+            return;
+        }
+        if ($sessionId !== null && $sessionId !== '') {
+            if (!preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $sessionId)) {
+                $this->writeErrorAndExit(400, 'bad_session_id', 'session_id must be a UUID v4.');
+                return;
+            }
+        }
+        foreach ($messages as $i => $msg) {
+            if (!is_array($msg)
+                || !isset($msg['role'])
+                || !in_array($msg['role'], self::ALLOWED_ROLES, true)
+                || !isset($msg['content'])
+                || !is_string($msg['content'])
+            ) {
+                $this->writeErrorAndExit(400, 'bad_message', "Message at index {$i} is malformed.");
+                return;
+            }
+        }
+
+        $upstream = [
+            'messages' => $messages,
+            'context' => $context,
+        ];
+        if ($sessionId !== null && $sessionId !== '') {
+            $upstream['session_id'] = $sessionId;
+        }
+
+        $roles = HttpClient::getUserRoles($user);
+        try {
+            $jwt = JWT::createMWToMCPToken($user, $roles, ['chat_completion']);
+        } catch (Throwable $e) {
+            $logger->error('Failed to mint JWT for streaming chat: {err}', ['err' => $e->getMessage()]);
+            $this->writeErrorAndExit(500, 'jwt_error', 'Could not create authentication token.');
+            return;
+        }
+
+        try {
+            $this->streamSse($upstream, $jwt);
+        } catch (Throwable $e) {
+            $logger->error('Streaming chat proxy failed: {err}', ['err' => $e->getMessage()]);
+            echo "event: error\ndata: " . json_encode([
+                'code' => 'proxy_failure',
+                'message' => 'Streaming connection failed.',
+            ]) . "\n\n";
+            @flush();
+        }
+    }
+
+    /**
+     * Open cURL stream to MCP /chat/stream and forward each chunk to the browser.
+     *
+     * @param array<string,mixed> $payload Validated upstream request body
+     * @param string $jwt MW-to-MCP token
+     */
+    private function streamSse(array $payload, string $jwt): void
+    {
+        header('Content-Type: text/event-stream; charset=utf-8');
+        header('Cache-Control: no-cache, no-store, must-revalidate');
+        header('Pragma: no-cache');
+        header('X-Accel-Buffering: no');
+        header('Connection: keep-alive');
+
+        while (ob_get_level() > 0) {
+            @ob_end_flush();
+        }
+        @ob_implicit_flush(true);
+
+        $url = Config::getMCPBaseUrl() . '/chat/stream';
+        $body = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($body === false) {
+            throw new \RuntimeException('Failed to encode upstream payload: ' . json_last_error_msg());
+        }
+
+        $ch = curl_init();
+        curl_setopt_array($ch, [
+            CURLOPT_URL => $url,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_HTTPHEADER => [
+                'Authorization: Bearer ' . $jwt,
+                'Content-Type: application/json',
+                'Accept: text/event-stream',
+                'User-Agent: MWAssistant/1.0.0 (MediaWiki streaming proxy)',
+                'X-Request-ID: ' . bin2hex(random_bytes(8)),
+            ],
+            CURLOPT_TIMEOUT => self::STREAM_TIMEOUT_SECONDS,
+            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_RETURNTRANSFER => false,
+            CURLOPT_HEADER => false,
+            CURLOPT_BUFFERSIZE => 256,
+            CURLOPT_TCP_NODELAY => true,
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+            CURLOPT_WRITEFUNCTION => function ($ch, $chunk) {
+                if (connection_aborted()) {
+                    return -1;
+                }
+                echo $chunk;
+                @flush();
+                return strlen($chunk);
+            },
+        ]);
+
+        $ok = curl_exec($ch);
+        $errno = curl_errno($ch);
+        $errstr = curl_error($ch);
+        $httpCode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if (!$ok && !connection_aborted()) {
+            $logger = LoggerFactory::getInstance(Config::LOGGER_CHANNEL);
+            $logger->warning('MCP /chat/stream cURL failed: errno={errno} err={err} http={http}', [
+                'errno' => $errno,
+                'err' => $errstr,
+                'http' => $httpCode,
+            ]);
+            echo "event: error\ndata: " . json_encode([
+                'code' => 'upstream_failure',
+                'message' => "Upstream MCP request failed (HTTP {$httpCode}).",
+            ]) . "\n\n";
+            @flush();
+        }
+    }
+
+    /**
+     * Send a JSON error response and stop. Only safe before SSE headers are sent.
+     */
+    private function writeErrorAndExit(int $httpCode, string $code, string $message): void
+    {
+        http_response_code($httpCode);
+        header('Content-Type: application/json');
+        echo json_encode(['error' => $code, 'message' => $message]);
+    }
+}

--- a/resources/mwassistant.chat.css
+++ b/resources/mwassistant.chat.css
@@ -401,3 +401,80 @@
     margin-bottom: 5px;
     color: #202124;
 }
+
+/* Streaming: pending tool block (spinner + status until result arrives) */
+.mwassistant-tool-pending .mwassistant-tool-summary {
+    background-color: #fff8e1;
+}
+
+.mwassistant-tool-spinner {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    margin: 0 6px;
+    border: 2px solid #c8ccd1;
+    border-top-color: #1a73e8;
+    border-radius: 50%;
+    animation: mwassistant-spin 0.8s linear infinite;
+    vertical-align: middle;
+}
+
+@keyframes mwassistant-spin {
+    to { transform: rotate(360deg); }
+}
+
+.mwassistant-tool-status {
+    font-size: 0.85em;
+    color: #5f6368;
+    font-style: italic;
+}
+
+.mwassistant-tool-elapsed {
+    margin-left: 8px;
+    font-size: 0.75em;
+    color: #80868b;
+    font-family: monospace;
+}
+
+.mwassistant-tool-error .mwassistant-tool-summary {
+    background-color: #fce8e6;
+}
+
+/* Streaming: "thinking..." indicator while waiting between events */
+.mwassistant-msg-thinking {
+    align-self: flex-start;
+    background-color: transparent;
+    color: #5f6368;
+    font-size: 0.9em;
+    padding: 4px 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    max-width: none;
+}
+
+.mwassistant-thinking-dots {
+    display: inline-flex;
+    gap: 3px;
+}
+
+.mwassistant-thinking-dots span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: #5f6368;
+    animation: mwassistant-thinking-pulse 1.2s infinite ease-in-out;
+}
+
+.mwassistant-thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
+.mwassistant-thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes mwassistant-thinking-pulse {
+    0%, 80%, 100% { opacity: 0.25; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1); }
+}
+
+.mwassistant-thinking-label {
+    color: #5f6368;
+    font-style: italic;
+}

--- a/resources/mwassistant.chat.js
+++ b/resources/mwassistant.chat.js
@@ -105,9 +105,9 @@
                         </div>
 
                         <div class="mwassistant-chat-input">
-                            <textarea 
-                                id="mwassistant-chat-input-text" 
-                                rows="3" 
+                            <textarea
+                                id="mwassistant-chat-input-text"
+                                rows="3"
                                 placeholder="What's on your mind?"
                             ></textarea>
                             <button id="mwassistant-chat-send">Send</button>
@@ -117,6 +117,7 @@
             `;
 
             this.$container.html(html);
+            this.$log = this.$container.find('#mwassistant-chat-log');
         }
 
         /* ------------------------------------------------------------------
@@ -180,7 +181,8 @@
         }
 
         async loadSession(sessionId) {
-            const $log = this.$container.find('#mwassistant-chat-log');
+            this._activeToolNodes.clear();
+            const $log = this.$log;
             $log.html('<div class="mwassistant-loading">Loading conversation...</div>');
 
             try {
@@ -237,9 +239,10 @@
         }
 
         startNewChat() {
+            this._activeToolNodes.clear();
             this.sessionId = null;
             this.$container.find('#mwassistant-chat-title').text('New Chat');
-            this.$container.find('#mwassistant-chat-log').html(`
+            this.$log.html(`
                 <div class="mwassistant-welcome">
                     <p>Welcome to MWAssistant! Ask me anything about this wiki.</p>
                 </div>
@@ -328,7 +331,7 @@
          * ------------------------------------------------------------------ */
 
         appendMessage(role, content) {
-            const $log = this.$container.find('#mwassistant-chat-log');
+            const $log = this.$log;
             
             // Remove welcome message if present
             $log.find('.mwassistant-welcome').remove();
@@ -447,7 +450,7 @@
          * Returns the jQuery node so it can later be upgraded with the result.
          */
         appendToolPending(toolName, rawArgs) {
-            const $log = this.$container.find('#mwassistant-chat-log');
+            const $log = this.$log;
             $log.find('.mwassistant-welcome').remove();
 
             const args = this.normalizeToolArgs(rawArgs);
@@ -508,12 +511,14 @@
             );
             $msg.find('.mwassistant-tool-result-content').html(displayResult);
 
-            const $log = this.$container.find('#mwassistant-chat-log');
+            const $log = this.$log;
             $log.scrollTop($log.prop('scrollHeight'));
         }
 
         /**
-         * Backwards-compatible single-shot tool render (used by non-streaming path).
+         * Render a tool block in one shot (no pending → final transition).
+         * Used by the buffered (non-streaming) path and as a fallback when a
+         * tool_result arrives without a matching tool_start.
          */
         appendToolMessage(toolName, rawArgs, result) {
             const $msg = this.appendToolPending(toolName, rawArgs);
@@ -525,7 +530,7 @@
          * Returns a function that removes the indicator.
          */
         showThinkingIndicator(label) {
-            const $log = this.$container.find('#mwassistant-chat-log');
+            const $log = this.$log;
             $log.find('.mwassistant-welcome').remove();
 
             const $msg = $('<div>').addClass('mwassistant-msg mwassistant-msg-thinking');
@@ -659,6 +664,7 @@
 
             const reader = res.body.getReader();
             const decoder = new TextDecoder();
+            const MAX_BUFFER_BYTES = 4 * 1024 * 1024;
             let buffer = '';
 
             try {
@@ -666,6 +672,12 @@
                     const { value, done } = await reader.read();
                     if (done) break;
                     buffer += decoder.decode(value, { stream: true });
+
+                    if (buffer.length > MAX_BUFFER_BYTES) {
+                        console.warn('MWAssistant: SSE buffer exceeded ' + MAX_BUFFER_BYTES + ' bytes; aborting stream.');
+                        await reader.cancel();
+                        break;
+                    }
 
                     let sepIndex;
                     while ((sepIndex = buffer.indexOf('\n\n')) !== -1) {
@@ -685,8 +697,9 @@
                             dismissThinking = null;
                         }
 
-                        const result = this.handleStreamEvent(parsed.event, parsed.data);
-                        if (result === 'final') sawFinalAssistant = true;
+                        if (this.handleStreamEvent(parsed.event, parsed.data)) {
+                            sawFinalAssistant = true;
+                        }
 
                         // After tool_result the LLM is thinking again until the next event.
                         if (parsed.event === 'tool_result' && !sawFinalAssistant) {
@@ -699,13 +712,13 @@
                 this._activeToolNodes.clear();
             }
 
-            // If the stream completed but no events ever arrived, the response
-            // body was empty — almost always a reverse-proxy / output-buffering
-            // issue between PHP and the browser. Surface it clearly instead of
-            // leaving the user staring at an empty chat.
+            // If the stream closed without any events, the response body was
+            // empty — almost always a reverse-proxy / output-buffering issue
+            // between PHP and the browser. Show a generic message; the
+            // diagnostic detail goes to console for the operator.
             if (!sawAnyEvent) {
-                console.warn('MWAssistant: stream closed with no events. Likely server-side buffering (mod_deflate / FastCGI). See Special:MWAssistantStream proxy notes.');
-                this.appendMessage('assistant', 'Error: the assistant connection closed without sending a response. This usually means the web server is buffering the streaming response. Check Apache mod_deflate and FastCGI flushpackets settings.');
+                console.warn('MWAssistant: stream closed with no events. Likely server-side buffering (Apache mod_deflate / FastCGI flushpackets). See Special:MWAssistantStream proxy notes.');
+                this.appendMessage('assistant', 'Error: the assistant connection closed before sending a response.');
             }
         }
 
@@ -744,8 +757,8 @@
         }
 
         /**
-         * Dispatch a parsed SSE event into UI updates. Returns 'final' when
-         * the user-visible answer was rendered (so the caller stops the
+         * Dispatch a parsed SSE event into UI updates. Returns true when the
+         * user-visible answer was rendered (so the caller stops the
          * "thinking" indicator).
          */
         handleStreamEvent(event, data) {
@@ -756,12 +769,12 @@
                         this.sessionId = data.session_id;
                         if (fresh) this.loadSessions();
                     }
-                    return null;
+                    return false;
                 }
                 case 'tool_start': {
                     const $node = this.appendToolPending(data.name, data.args || {});
                     if (data.call_id) this._activeToolNodes.set(data.call_id, $node);
-                    return null;
+                    return false;
                 }
                 case 'tool_result': {
                     const $node = data.call_id
@@ -777,33 +790,27 @@
                         // No matching start — render in one shot as a fallback.
                         this.appendToolMessage(data.name, {}, data.result_preview);
                     }
-                    return null;
+                    return false;
                 }
                 case 'assistant_message': {
-                    if (!data.content) return null;
-                    if (data.is_final) {
-                        this.appendMessage('assistant', data.content);
-                        return 'final';
-                    }
-                    // Intermediate assistant text (between tool calls) — render
-                    // so the user sees the model's narration.
+                    if (!data.content) return false;
                     this.appendMessage('assistant', data.content);
-                    return null;
+                    return !!data.is_final;
                 }
                 case 'error': {
                     const msg = (data && data.message) || 'The assistant ran into an error.';
                     this.appendMessage('assistant', 'Error: ' + msg);
-                    return 'final';
+                    return true;
                 }
                 case 'done': {
                     // Refresh sidebar so the new title appears for first turns.
                     if (data.session_id && !this.hideSessions) {
                         this.loadSessions();
                     }
-                    return null;
+                    return false;
                 }
                 default:
-                    return null;
+                    return false;
             }
         }
 

--- a/resources/mwassistant.chat.js
+++ b/resources/mwassistant.chat.js
@@ -67,6 +67,10 @@
             this.sessions = [];
             this.mwApi = new mw.Api();
 
+            // Per-stream UI state — maps tool call_id -> jQuery node so we can
+            // upgrade tool_start placeholders into final tool_result rows.
+            this._activeToolNodes = new Map();
+
             this.renderUI();
             this.bindEvents();
             this.loadSessions();
@@ -341,122 +345,200 @@
             $log.scrollTop($log.prop('scrollHeight'));
         }
 
-        appendToolMessage(toolName, rawArgs, result) {
-            const $log = this.$container.find('#mwassistant-chat-log');
-            let args = {};
-            try {
-                args = typeof rawArgs === 'string' ? JSON.parse(rawArgs) : rawArgs;
-            } catch (e) { args = { raw: rawArgs }; }
-
-            let displayQuery = "";
-            let displayResult = "";
-            let headerTitle = "Tool Execution";
-
-            // Format Header & Query based on tool type
+        /**
+         * Build a "human-friendly" header + query string for a tool call.
+         */
+        formatToolHeader(toolName, args) {
             switch (toolName) {
                 case 'mw_run_smw_ask':
-                    headerTitle = "SMW Query";
-                    displayQuery = args.ask || "No query";
-                    break;
+                    return { headerTitle: 'SMW Query', displayQuery: args.ask || 'No query' };
                 case 'mw_get_page':
-                    headerTitle = "Read Page";
-                    displayQuery = args.title || "Unknown Page";
-                    break;
-                case 'mw_get_categories':
-                    headerTitle = "Category Check";
-                    if (args.names) displayQuery = "Checking: " + args.names.join(", ");
-                    else if (args.prefix) displayQuery = "Search: " + args.prefix;
-                    else displayQuery = "List all";
-                    break;
-                case 'mw_get_properties':
-                    headerTitle = "Property Check";
-                    if (args.names) displayQuery = "Checking: " + args.names.join(", ");
-                    else if (args.prefix) displayQuery = "Search: " + args.prefix;
-                    else displayQuery = "List all";
-                    break;
+                    return { headerTitle: 'Read Page', displayQuery: args.title || 'Unknown Page' };
+                case 'mw_page_info':
+                    return { headerTitle: 'Page Info', displayQuery: args.title || 'Unknown Page' };
+                case 'mw_search_pages':
+                    return { headerTitle: 'Keyword Search', displayQuery: args.query || '' };
                 case 'mw_vector_search':
-                    headerTitle = "Vector Search";
-                    displayQuery = args.query || "";
-                    break;
+                    return { headerTitle: 'Vector Search', displayQuery: args.query || '' };
+                case 'mw_get_categories':
+                case 'mw_get_properties': {
+                    const label = toolName === 'mw_get_categories' ? 'Category Check' : 'Property Check';
+                    if (args.names) return { headerTitle: label, displayQuery: 'Checking: ' + args.names.join(', ') };
+                    if (args.prefix) return { headerTitle: label, displayQuery: 'Search: ' + args.prefix };
+                    return { headerTitle: label, displayQuery: 'List all' };
+                }
+                case 'mw_list_pages':
+                    return { headerTitle: 'List Pages', displayQuery: args.namespace || args.prefix || 'all' };
+                case 'mw_get_category_members':
+                    return { headerTitle: 'Category Members', displayQuery: args.category || '' };
                 default:
-                    headerTitle = toolName;
-                    displayQuery = JSON.stringify(args);
+                    return { headerTitle: toolName, displayQuery: JSON.stringify(args) };
             }
+        }
 
-            // Generate Preview Text (Query)
-            let queryPreview = typeof displayQuery === 'string' ? displayQuery : JSON.stringify(displayQuery);
-            if (queryPreview.length > 50) queryPreview = queryPreview.substring(0, 50) + "...";
-
-            // Format Result & Preview
-            let resultPreview = "";
+        /**
+         * Render the result body + preview for a tool call. Returns
+         * { displayResult: <html>, resultPreview: <text> }.
+         */
+        formatToolResult(toolName, result) {
+            let displayResult = '';
+            let resultPreview = '';
 
             if (result && result.error) {
-                displayResult = `<span class="mwassistant-error">${result.error}</span>`;
+                displayResult = `<span class="mwassistant-error">${this.escapeHtml(result.error)}</span>`;
                 resultPreview = `Error: ${result.error}`;
             } else if (toolName === 'mw_run_smw_ask') {
-                if (result['mwassistant-smw']?.result) {
+                if (result && result['mwassistant-smw'] && result['mwassistant-smw'].result) {
                     displayResult = result['mwassistant-smw'].result;
-                    resultPreview = "SMW Result";
+                    resultPreview = 'SMW Result';
                 } else {
-                    displayResult = JSON.stringify(result, null, 2);
-                    resultPreview = "JSON Result";
+                    displayResult = `<pre>${this.escapeHtml(JSON.stringify(result, null, 2))}</pre>`;
+                    resultPreview = 'JSON Result';
                 }
             } else if (Array.isArray(result)) {
                 if (result.length === 0) {
-                    displayResult = "<em>No matches found.</em>";
-                    resultPreview = "No matches";
+                    displayResult = '<em>No matches found.</em>';
+                    resultPreview = 'No matches';
                 } else if (typeof result[0] === 'string') {
-                    displayResult = `<ul class="mwassistant-tool-list">${result.map(x => `<li>${x}</li>`).join('')}</ul>`;
-                    resultPreview = result.join(", ");
-                } else if (result[0]?.title && result[0]?.score) {
-                    displayResult = `<ul class="mwassistant-tool-list">
-                        ${result.map(x => `<li><b>[[${x.title}]]</b> (Score: ${x.score.toFixed(2)})</li>`).join('')}
-                    </ul>`;
+                    displayResult = `<ul class="mwassistant-tool-list">${result.map(x => `<li>${this.escapeHtml(x)}</li>`).join('')}</ul>`;
+                    resultPreview = result.join(', ');
+                } else if (result[0] && result[0].title && typeof result[0].score === 'number') {
+                    displayResult = `<ul class="mwassistant-tool-list">${
+                        result.map(x => `<li><b>[[${this.escapeHtml(x.title)}]]</b> (Score: ${x.score.toFixed(2)})</li>`).join('')
+                    }</ul>`;
                     resultPreview = `${result.length} results found`;
                 } else {
-                    displayResult = `<pre>${JSON.stringify(result, null, 2)}</pre>`;
-                    resultPreview = "Array Result";
+                    displayResult = `<pre>${this.escapeHtml(JSON.stringify(result, null, 2))}</pre>`;
+                    resultPreview = 'Array Result';
                 }
             } else if (typeof result === 'string') {
                 const maxLen = 500;
                 resultPreview = result;
                 if (result.length > maxLen) {
-                    displayResult = `<div class="mwassistant-collapsed-content">
-                        ${$('<div>').text(result.substring(0, maxLen)).html()}...
-                        <br><em>(${result.length} chars total)</em>
-                    </div>`;
+                    displayResult = `<div class="mwassistant-collapsed-content">${
+                        this.escapeHtml(result.substring(0, maxLen))
+                    }...<br><em>(${result.length} chars total)</em></div>`;
                 } else {
-                    displayResult = $('<div>').text(result).html();
+                    displayResult = this.escapeHtml(result);
                 }
             } else {
-                displayResult = `<pre>${JSON.stringify(result, null, 2)}</pre>`;
-                resultPreview = "Output Object";
+                displayResult = `<pre>${this.escapeHtml(JSON.stringify(result, null, 2))}</pre>`;
+                resultPreview = 'Output Object';
             }
 
-            // Truncate result preview
-            if (resultPreview.length > 50) resultPreview = resultPreview.substring(0, 50) + "...";
+            if (resultPreview.length > 50) resultPreview = resultPreview.substring(0, 50) + '...';
+            return { displayResult, resultPreview };
+        }
+
+        /**
+         * Convert raw tool args (string-encoded JSON or object) into a plain object.
+         */
+        normalizeToolArgs(rawArgs) {
+            try {
+                return typeof rawArgs === 'string' ? JSON.parse(rawArgs) : (rawArgs || {});
+            } catch (e) {
+                return { raw: rawArgs };
+            }
+        }
+
+        /**
+         * Render a tool block in "running" state — shown immediately when a
+         * tool_start event arrives so the user sees what's happening.
+         * Returns the jQuery node so it can later be upgraded with the result.
+         */
+        appendToolPending(toolName, rawArgs) {
+            const $log = this.$container.find('#mwassistant-chat-log');
+            $log.find('.mwassistant-welcome').remove();
+
+            const args = this.normalizeToolArgs(rawArgs);
+            const { headerTitle, displayQuery } = this.formatToolHeader(toolName, args);
+            let queryPreview = typeof displayQuery === 'string' ? displayQuery : JSON.stringify(displayQuery);
+            if (queryPreview.length > 50) queryPreview = queryPreview.substring(0, 50) + '...';
 
             const $msg = $('<div>').addClass('mwassistant-msg mwassistant-msg-tool');
-
-            const html = `
-                <details class="mwassistant-tool-details">
+            $msg.html(`
+                <details class="mwassistant-tool-details mwassistant-tool-pending">
                     <summary class="mwassistant-tool-summary">
-                        <span class="mwassistant-tool-name">${headerTitle}</span>
-                        <span class="mwassistant-tool-preview"><span class="mwassistant-tool-preview-query">${$('<div>').text(queryPreview).html()}</span> &rarr; <span class="mwassistant-tool-preview-result">${$('<div>').text(resultPreview).html()}</span></span>
+                        <span class="mwassistant-tool-name">${this.escapeHtml(headerTitle)}</span>
+                        <span class="mwassistant-tool-preview">
+                            <span class="mwassistant-tool-preview-query">${this.escapeHtml(queryPreview)}</span>
+                            <span class="mwassistant-tool-spinner" aria-hidden="true"></span>
+                            <span class="mwassistant-tool-status">Running...</span>
+                        </span>
                     </summary>
                     <div class="mwassistant-tool-expanded">
-                        <div class="mwassistant-tool-query"><code>${$('<div>').text(displayQuery).html()}</code></div>
+                        <div class="mwassistant-tool-query"><code>${this.escapeHtml(String(displayQuery))}</code></div>
                         <div class="mwassistant-tool-result">
                             <div class="mwassistant-tool-result-header">Result:</div>
-                            <div class="mwassistant-tool-result-content">${displayResult}</div>
+                            <div class="mwassistant-tool-result-content"><em>Waiting for response…</em></div>
                         </div>
                     </div>
                 </details>
-            `;
+            `);
 
-            $msg.html(html);
             $log.append($msg);
             $log.scrollTop($log.prop('scrollHeight'));
+            return $msg;
+        }
+
+        /**
+         * Upgrade a "running" tool block in place once the result arrives.
+         */
+        finalizeToolMessage($msg, toolName, result, opts) {
+            opts = opts || {};
+            const { displayResult, resultPreview } = this.formatToolResult(toolName, result);
+            const elapsedMs = typeof opts.elapsedMs === 'number' ? opts.elapsedMs : null;
+            const ok = opts.ok !== false;
+
+            $msg.find('.mwassistant-tool-details')
+                .removeClass('mwassistant-tool-pending')
+                .toggleClass('mwassistant-tool-error', !ok);
+            $msg.find('.mwassistant-tool-spinner').remove();
+            $msg.find('.mwassistant-tool-status').remove();
+
+            const elapsedTag = elapsedMs !== null
+                ? ` <span class="mwassistant-tool-elapsed">${elapsedMs} ms</span>`
+                : '';
+            $msg.find('.mwassistant-tool-preview').html(
+                `<span class="mwassistant-tool-preview-query">${
+                    this.escapeHtml($msg.find('.mwassistant-tool-preview-query').text())
+                }</span> &rarr; <span class="mwassistant-tool-preview-result">${
+                    this.escapeHtml(resultPreview)
+                }</span>${elapsedTag}`
+            );
+            $msg.find('.mwassistant-tool-result-content').html(displayResult);
+
+            const $log = this.$container.find('#mwassistant-chat-log');
+            $log.scrollTop($log.prop('scrollHeight'));
+        }
+
+        /**
+         * Backwards-compatible single-shot tool render (used by non-streaming path).
+         */
+        appendToolMessage(toolName, rawArgs, result) {
+            const $msg = this.appendToolPending(toolName, rawArgs);
+            this.finalizeToolMessage($msg, toolName, result, { ok: !(result && result.error) });
+        }
+
+        /**
+         * Render a "thinking..." indicator while waiting for the next event.
+         * Returns a function that removes the indicator.
+         */
+        showThinkingIndicator(label) {
+            const $log = this.$container.find('#mwassistant-chat-log');
+            $log.find('.mwassistant-welcome').remove();
+
+            const $msg = $('<div>').addClass('mwassistant-msg mwassistant-msg-thinking');
+            $msg.html(`
+                <span class="mwassistant-thinking-dots" aria-hidden="true">
+                    <span></span><span></span><span></span>
+                </span>
+                <span class="mwassistant-thinking-label">${this.escapeHtml(label || 'Thinking…')}</span>
+            `);
+            $log.append($msg);
+            $log.scrollTop($log.prop('scrollHeight'));
+
+            return () => $msg.remove();
         }
 
         /* ------------------------------------------------------------------
@@ -521,20 +603,206 @@
             $input.val('');
             this.appendMessage('user', text);
 
-            const payload = this.buildPayload(text);
-
             const $btn = this.$container.find('#mwassistant-chat-send');
             $btn.prop('disabled', true);
 
             try {
-                const data = await this.mwApi.post(payload);
-                this.handleResponse(data);
+                if (typeof window.fetch === 'function' && window.ReadableStream) {
+                    await this.sendMessageStreaming(text);
+                } else {
+                    await this.sendMessageBuffered(text);
+                }
             } catch (err) {
-                console.error("MWAssistant API error:", err);
+                console.error('MWAssistant API error:', err);
                 this.appendMessage('assistant', 'Error: failed to reach server.');
             } finally {
                 $btn.prop('disabled', false);
             }
+        }
+
+        /**
+         * Streaming path: POST to Special:MWAssistantStream and parse SSE
+         * frames so we can render each tool step as it happens.
+         */
+        async sendMessageStreaming(text) {
+            const messages = this.buildMessagesArray(text);
+            const body = { messages, context: this.context };
+            if (this.sessionId) body.session_id = this.sessionId;
+
+            const url = mw.util.getUrl('Special:MWAssistantStream') +
+                '?token=' + encodeURIComponent(mw.user.tokens.get('csrfToken'));
+
+            const res = await fetch(url, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'text/event-stream',
+                },
+                body: JSON.stringify(body),
+            });
+
+            if (!res.ok || !res.body) {
+                let detail = 'Failed to reach server.';
+                try {
+                    const errBody = await res.json();
+                    if (errBody && errBody.message) detail = errBody.message;
+                } catch (_) { /* ignore */ }
+                this.appendMessage('assistant', 'Error: ' + detail);
+                return;
+            }
+
+            this._activeToolNodes.clear();
+            let dismissThinking = this.showThinkingIndicator('Thinking…');
+            let sawFinalAssistant = false;
+
+            const reader = res.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
+
+            try {
+                while (true) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+                    buffer += decoder.decode(value, { stream: true });
+
+                    let sepIndex;
+                    while ((sepIndex = buffer.indexOf('\n\n')) !== -1) {
+                        const frame = buffer.slice(0, sepIndex);
+                        buffer = buffer.slice(sepIndex + 2);
+                        const parsed = this.parseSseFrame(frame);
+                        if (!parsed) continue;
+
+                        // Hide the placeholder spinner the instant any signal arrives.
+                        if (dismissThinking) {
+                            dismissThinking();
+                            dismissThinking = null;
+                        }
+
+                        const result = this.handleStreamEvent(parsed.event, parsed.data);
+                        if (result === 'final') sawFinalAssistant = true;
+
+                        // After tool_result the LLM is thinking again until the next event.
+                        if (parsed.event === 'tool_result' && !sawFinalAssistant) {
+                            dismissThinking = this.showThinkingIndicator('Thinking…');
+                        }
+                    }
+                }
+            } finally {
+                if (dismissThinking) dismissThinking();
+                this._activeToolNodes.clear();
+            }
+        }
+
+        /**
+         * Fallback path (older browsers without fetch streams): use the
+         * legacy buffered API endpoint and render once everything finishes.
+         */
+        async sendMessageBuffered(text) {
+            const payload = this.buildPayload(text);
+            const data = await this.mwApi.post(payload);
+            this.handleResponse(data);
+        }
+
+        /**
+         * Parse a single SSE frame ("event: foo\ndata: {...}").
+         */
+        parseSseFrame(raw) {
+            const lines = raw.split('\n');
+            let event = 'message';
+            const dataLines = [];
+            for (const line of lines) {
+                if (line.startsWith('event:')) {
+                    event = line.slice(6).trim();
+                } else if (line.startsWith('data:')) {
+                    dataLines.push(line.slice(5).trim());
+                }
+            }
+            if (dataLines.length === 0) return null;
+            const dataStr = dataLines.join('\n');
+            try {
+                return { event, data: JSON.parse(dataStr) };
+            } catch (e) {
+                console.warn('Failed to parse SSE frame:', dataStr);
+                return null;
+            }
+        }
+
+        /**
+         * Dispatch a parsed SSE event into UI updates. Returns 'final' when
+         * the user-visible answer was rendered (so the caller stops the
+         * "thinking" indicator).
+         */
+        handleStreamEvent(event, data) {
+            switch (event) {
+                case 'session': {
+                    if (data.session_id && data.session_id !== this.sessionId) {
+                        const fresh = !this.sessionId;
+                        this.sessionId = data.session_id;
+                        if (fresh) this.loadSessions();
+                    }
+                    return null;
+                }
+                case 'tool_start': {
+                    const $node = this.appendToolPending(data.name, data.args || {});
+                    if (data.call_id) this._activeToolNodes.set(data.call_id, $node);
+                    return null;
+                }
+                case 'tool_result': {
+                    const $node = data.call_id
+                        ? this._activeToolNodes.get(data.call_id)
+                        : null;
+                    if ($node) {
+                        this._activeToolNodes.delete(data.call_id);
+                        this.finalizeToolMessage($node, data.name, data.result_preview, {
+                            ok: data.ok !== false,
+                            elapsedMs: data.elapsed_ms,
+                        });
+                    } else {
+                        // No matching start — render in one shot as a fallback.
+                        this.appendToolMessage(data.name, {}, data.result_preview);
+                    }
+                    return null;
+                }
+                case 'assistant_message': {
+                    if (!data.content) return null;
+                    if (data.is_final) {
+                        this.appendMessage('assistant', data.content);
+                        return 'final';
+                    }
+                    // Intermediate assistant text (between tool calls) — render
+                    // so the user sees the model's narration.
+                    this.appendMessage('assistant', data.content);
+                    return null;
+                }
+                case 'error': {
+                    const msg = (data && data.message) || 'The assistant ran into an error.';
+                    this.appendMessage('assistant', 'Error: ' + msg);
+                    return 'final';
+                }
+                case 'done': {
+                    // Refresh sidebar so the new title appears for first turns.
+                    if (data.session_id && !this.hideSessions) {
+                        this.loadSessions();
+                    }
+                    return null;
+                }
+                default:
+                    return null;
+            }
+        }
+
+        /**
+         * Build just the messages array (for streaming endpoint payload).
+         */
+        buildMessagesArray(userText) {
+            const messages = [];
+            const extra = this.getExtraContext();
+            if (extra) {
+                messages.push({ role: 'system', content: 'Context:\n' + extra });
+            }
+            messages.push({ role: 'user', content: userText });
+            return messages;
         }
 
         /* ------------------------------------------------------------------

--- a/resources/mwassistant.chat.js
+++ b/resources/mwassistant.chat.js
@@ -655,6 +655,7 @@
             this._activeToolNodes.clear();
             let dismissThinking = this.showThinkingIndicator('Thinking…');
             let sawFinalAssistant = false;
+            let sawAnyEvent = false;
 
             const reader = res.body.getReader();
             const decoder = new TextDecoder();
@@ -672,6 +673,11 @@
                         buffer = buffer.slice(sepIndex + 2);
                         const parsed = this.parseSseFrame(frame);
                         if (!parsed) continue;
+                        sawAnyEvent = true;
+
+                        // Heartbeat just confirms the pipe is alive — don't
+                        // surface it, but it does count as "we got bytes".
+                        if (parsed.event === 'heartbeat') continue;
 
                         // Hide the placeholder spinner the instant any signal arrives.
                         if (dismissThinking) {
@@ -691,6 +697,15 @@
             } finally {
                 if (dismissThinking) dismissThinking();
                 this._activeToolNodes.clear();
+            }
+
+            // If the stream completed but no events ever arrived, the response
+            // body was empty — almost always a reverse-proxy / output-buffering
+            // issue between PHP and the browser. Surface it clearly instead of
+            // leaving the user staring at an empty chat.
+            if (!sawAnyEvent) {
+                console.warn('MWAssistant: stream closed with no events. Likely server-side buffering (mod_deflate / FastCGI). See Special:MWAssistantStream proxy notes.');
+                this.appendMessage('assistant', 'Error: the assistant connection closed without sending a response. This usually means the web server is buffering the streaming response. Check Apache mod_deflate and FastCGI flushpackets settings.');
             }
         }
 


### PR DESCRIPTION
## Summary

Make the chat feel responsive: each tool call now renders in the chat window as it happens instead of all at once when the full LLM tool loop finishes. Pairs with the new \`POST /chat/stream\` SSE endpoint on the MCP server.

## What changed

- **New \`Special:MWAssistantStream\`** — bypasses the MW API framework's buffered ApiResult and forwards SSE bytes from \`mw-mcp-server /chat/stream\` straight to the browser. Mints the short-lived MW→MCP JWT server-side so the browser never sees the secret. CSRF-protected via the standard edit token.
- **Chat JS rewrite of the send pipeline** — \`fetch()\` + \`ReadableStream\` parse SSE frames as they arrive:
  - \`tool_start\` → renders an immediate "running…" tool block with a spinner.
  - \`tool_result\` → upgrades that block in place with the actual result + elapsed time.
  - \`assistant_message\` → streams intermediate and final assistant text.
  - \`session\` → grabs the new \`session_id\` on first turn so the sidebar updates immediately.
  - \`error\` → surfaces a user-readable error and stops the stream.
- **"Thinking…" indicator** — pulsing dots shown while the LLM is working between events. Auto-removed the moment any signal arrives, re-shown after each \`tool_result\` until the final message lands.
- **Graceful fallback** — browsers without \`fetch\` streams fall through to the legacy \`mwassistant-chat\` API call.

## Why a SpecialPage instead of a new \`mwassistant-stream\` API module

MediaWiki's API framework collects responses through \`ApiResult\` and only flushes once \`execute()\` returns — there's no streaming primitive. Doing this inside an \`ApiBase\` subclass would either mean monkey-patching the result pipeline or echoing raw bytes from inside the API hook (which fights the framework). An \`UnlistedSpecialPage\` with \`OutputPage::disable()\` is the standard escape hatch and keeps things clean.

## Reverse-proxy note

Streaming requires nginx/Cloudflare not to buffer. The PHP proxy already sends \`X-Accel-Buffering: no\` and \`Cache-Control: no-cache\`, but front-end nginx config should set:

\`\`\`nginx
location /index.php {
    proxy_buffering off;
    proxy_read_timeout 300s;
}
\`\`\`

(or scope to \`?title=Special:MWAssistantStream\` if you only want it for the streaming path).

## Test plan

- [ ] Send a message that triggers tool calls (e.g. asking about a wiki page) and confirm tool blocks appear progressively, not all at once.
- [ ] Confirm the "Thinking…" indicator appears before the first event and between tool_result and the next event.
- [ ] Confirm session sidebar updates with the new session title after the first turn.
- [ ] Confirm \`Special:MWAssistantStream\` returns 403/400 on missing CSRF token / bad JSON / wrong method.
- [ ] Confirm the legacy \`mwassistant-chat\` API still works (load page, manually disable \`fetch\` if possible, send a message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)