### PR TITLE
Embeddings dashboard overhaul: JobQueue, rev_id, MW Assistant rename

### DIFF
--- a/MWAssistant.alias.php
+++ b/MWAssistant.alias.php
@@ -10,6 +10,6 @@ $specialPageAliases = [];
 
 /** English (English) */
 $specialPageAliases['en'] = [
-    'MWAssistant' => ['MWAssistant', 'AI Assistant', 'AIAssistant'],
+    'MWAssistant' => ['MWAssistant', 'MW Assistant', 'MWAssistantChat'],
     'MWAssistantEmbeddings' => ['MWAssistantEmbeddings', 'EmbeddingsStatus'],
 ];

--- a/extension.json
+++ b/extension.json
@@ -66,6 +66,10 @@
             "styles": [
                 "resources/mwassistant.global.css"
             ],
+            "messages": [
+                "mwassistant-search-icon-title",
+                "mwassistant-search-icon-label"
+            ],
             "dependencies": [
                 "mediawiki.util",
                 "jquery"
@@ -111,7 +115,12 @@
     "Hooks": {
         "BeforePageDisplay": "MWAssistant\\Hooks\\MWAssistantHooks::onBeforePageDisplay",
         "PageSaveComplete": "MWAssistant\\Hooks\\AutoEmbeddingHooks::onPageSaveComplete",
-        "PageDeleteComplete": "MWAssistant\\Hooks\\AutoEmbeddingHooks::onPageDeleteComplete"
+        "PageDeleteComplete": "MWAssistant\\Hooks\\AutoEmbeddingHooks::onPageDeleteComplete",
+        "PageMoveComplete": "MWAssistant\\Hooks\\AutoEmbeddingHooks::onPageMoveComplete"
+    },
+    "JobClasses": {
+        "mwassistantUpdateEmbedding": "MWAssistant\\Jobs\\UpdateEmbeddingJob",
+        "mwassistantDeleteEmbedding": "MWAssistant\\Jobs\\DeleteEmbeddingJob"
     },
     "AvailableRights": [
         "mwassistant-use"

--- a/extension.json
+++ b/extension.json
@@ -165,6 +165,14 @@
         "MWAssistantWikiApiUrl": {
             "value": "",
             "description": "Publicly accessible API URL for this wiki (e.g. https://wiki.example.com/api.php)"
+        },
+        "MWAssistantEmbedSkipNamespaces": {
+            "value": [2],
+            "description": "Namespace IDs to skip when auto-embedding. Default skips NS_USER (2) since user pages are usually personal/scratch content. Set to [] to embed everything."
+        },
+        "MWAssistantEmbedTalkPages": {
+            "value": false,
+            "description": "If false (default), talk pages are skipped from auto-embedding. Set true on wikis where talk-page content is part of the searchable knowledge base."
         }
     },
     "manifest_version": 2

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2,11 +2,22 @@
     "@metadata": {
         "authors": []
     },
-    "mwassistant-desc": "AI Assistant integration using MCP",
-    "mwassistant": "MWAssistant",
-    "mwassistant-chat-title": "AI Assistant",
-    "right-mwassistant-use": "Use MWAssistant AI features",
-    "action-mwassistant-use": "use MWAssistant AI features",
+    "mwassistant-desc": "MW Assistant — MediaWiki-aware AI assistant powered by MCP.",
+    "mwassistant": "MW Assistant",
+    "mwassistant-summary": "Chat with the wiki's MW Assistant. Ask questions about pages, categories, and structured data.",
+    "mwassistant-chat-title": "MW Assistant",
+    "mwassistantembeddings": "MW Assistant: Embeddings",
+    "mwassistantembeddings-summary": "Inspect vector embedding status by namespace and trigger updates for individual pages or whole namespaces.",
+    "mwassistantembeddings-pagetitle": "Vector embeddings status",
+    "mwassistantstream": "MW Assistant chat stream",
+    "right-mwassistant-use": "Use MW Assistant features",
+    "action-mwassistant-use": "use MW Assistant features",
     "apierror-mwassistant-invalid-jwt": "JWT verification failed. Token may be expired, have an invalid signature, or have insufficient scope.",
-    "specialpages-group-labki": "Labki"
+    "specialpages-group-labki": "Labki",
+    "mwassistant-search-icon-title": "Ask MW Assistant about this query",
+    "mwassistant-search-icon-label": "Ask MW Assistant",
+    "mwassistantembeddings-batch-queued": "Queued <b>$1</b> page {{PLURAL:$1|update|updates}} in namespace $2 for background processing. {{PLURAL:$3|$3 page is|$3 pages are}} already up to date and were skipped.",
+    "mwassistantembeddings-batch-nothing-to-do": "Nothing to do — {{PLURAL:$1|the page is|all $1 pages are}} already up to date.",
+    "mwassistantembeddings-single-queued": "Queued an embedding update for <b>$1</b>.",
+    "mwassistantembeddings-reload-hint": "Reload this page to see progress."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -16,8 +16,9 @@
     "specialpages-group-labki": "Labki",
     "mwassistant-search-icon-title": "Ask MW Assistant about this query",
     "mwassistant-search-icon-label": "Ask MW Assistant",
-    "mwassistantembeddings-batch-queued": "Queued <b>$1</b> page {{PLURAL:$1|update|updates}} in namespace $2 for background processing. {{PLURAL:$3|$3 page is|$3 pages are}} already up to date and were skipped.",
+    "mwassistantembeddings-batch-queued": "Queued <b>$1</b> page {{PLURAL:$1|update|updates}} for background processing. {{PLURAL:$2|$2 page is|$2 pages are}} already up to date.",
     "mwassistantembeddings-batch-nothing-to-do": "Nothing to do — {{PLURAL:$1|the page is|all $1 pages are}} already up to date.",
     "mwassistantembeddings-single-queued": "Queued an embedding update for <b>$1</b>.",
+    "mwassistantembeddings-jobs-pending": "<b>$1</b> embedding {{PLURAL:$1|job is|jobs are}} still pending.",
     "mwassistantembeddings-reload-hint": "Reload this page to see progress."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,0 +1,23 @@
+{
+    "@metadata": {
+        "authors": []
+    },
+    "mwassistant-desc": "Short description of the MW Assistant extension shown on Special:Version.",
+    "mwassistant": "Display name of the [[Special:MWAssistant]] page in the special-pages listing.",
+    "mwassistant-summary": "One-sentence description shown under the special-page link in [[Special:SpecialPages]].",
+    "mwassistant-chat-title": "Heading shown above the chat UI on Special:MWAssistant.",
+    "mwassistantembeddings": "Display name of the [[Special:MWAssistantEmbeddings]] page in the special-pages listing.",
+    "mwassistantembeddings-summary": "One-sentence description shown under the special-page link in [[Special:SpecialPages]].",
+    "mwassistantembeddings-pagetitle": "Page title rendered at the top of [[Special:MWAssistantEmbeddings]].",
+    "mwassistantstream": "Internal name for the SSE streaming endpoint Special:MWAssistantStream. The page is unlisted, so this is mostly seen in URLs and logs.",
+    "right-mwassistant-use": "Permission label for the 'mwassistant-use' user right (shown in [[Special:ListGroupRights]]).",
+    "action-mwassistant-use": "Action label used in log entries when a user invokes MWAssistant features.",
+    "apierror-mwassistant-invalid-jwt": "API error returned when an MWAssistant request carries an invalid or expired JWT.",
+    "specialpages-group-labki": "Heading for the Labki group on [[Special:SpecialPages]] (shared with sister extensions like SemanticSchemas).",
+    "mwassistant-search-icon-title": "Tooltip shown when hovering over the MW Assistant shortcut icon next to the search input.",
+    "mwassistant-search-icon-label": "Accessible label (aria-label) for the MW Assistant shortcut icon next to the search input.",
+    "mwassistantembeddings-batch-queued": "Banner shown after a successful batch enqueue on Special:MWAssistantEmbeddings. $1 = number of jobs enqueued, $2 = namespace ID, $3 = number of pages skipped because already in sync.",
+    "mwassistantembeddings-batch-nothing-to-do": "Banner shown when a batch enqueue had no work to do. $1 = number of pages already in sync.",
+    "mwassistantembeddings-single-queued": "Banner shown after a successful single-page embedding enqueue. $1 = page title.",
+    "mwassistantembeddings-reload-hint": "Trailing instruction in the batch banner pointing the user at the reload control."
+}

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -16,8 +16,9 @@
     "specialpages-group-labki": "Heading for the Labki group on [[Special:SpecialPages]] (shared with sister extensions like SemanticSchemas).",
     "mwassistant-search-icon-title": "Tooltip shown when hovering over the MW Assistant shortcut icon next to the search input.",
     "mwassistant-search-icon-label": "Accessible label (aria-label) for the MW Assistant shortcut icon next to the search input.",
-    "mwassistantembeddings-batch-queued": "Banner shown after a successful batch enqueue on Special:MWAssistantEmbeddings. $1 = number of jobs enqueued, $2 = namespace ID, $3 = number of pages skipped because already in sync.",
-    "mwassistantembeddings-batch-nothing-to-do": "Banner shown when a batch enqueue had no work to do. $1 = number of pages already in sync.",
-    "mwassistantembeddings-single-queued": "Banner shown after a successful single-page embedding enqueue. $1 = page title.",
-    "mwassistantembeddings-reload-hint": "Trailing instruction in the batch banner pointing the user at the reload control."
+    "mwassistantembeddings-batch-queued": "Transient success notice shown immediately after a batch enqueue. $1 = number of jobs enqueued, $2 = number of pages skipped because already in sync.",
+    "mwassistantembeddings-batch-nothing-to-do": "Notice shown when a batch enqueue had no work to do. $1 = number of pages already in sync.",
+    "mwassistantembeddings-single-queued": "Notice shown after a successful single-page embedding enqueue. $1 = page title.",
+    "mwassistantembeddings-jobs-pending": "Persistent banner shown on every page render while embedding jobs are still in the queue. $1 = total pending count (waiting + currently running).",
+    "mwassistantembeddings-reload-hint": "Trailing instruction in the pending-jobs banner pointing the user at the reload control."
 }

--- a/includes/Config.php
+++ b/includes/Config.php
@@ -123,6 +123,11 @@ class Config
     }
 
     /**
+     * System user name used by background embedding jobs to mint MCP JWTs.
+     */
+    public const SYSTEM_USER_NAME = 'MWAssistant Embedder';
+
+    /**
      * Whether automatic embedding updates are enabled.
      *
      * @return bool

--- a/includes/Config.php
+++ b/includes/Config.php
@@ -133,6 +133,36 @@ class Config
     }
 
     /**
+     * Namespace IDs that should never be embedded.
+     *
+     * @return int[]
+     */
+    public static function getEmbedSkipNamespaces(): array
+    {
+        $raw = self::cfg()->get('MWAssistantEmbedSkipNamespaces');
+        if (!is_array($raw)) {
+            return [];
+        }
+        $out = [];
+        foreach ($raw as $ns) {
+            if (is_int($ns) || (is_string($ns) && ctype_digit($ns))) {
+                $out[] = (int) $ns;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Whether talk-namespace pages should be embedded.
+     *
+     * @return bool
+     */
+    public static function shouldEmbedTalkPages(): bool
+    {
+        return (bool) self::cfg()->get('MWAssistantEmbedTalkPages');
+    }
+
+    /**
      * Unique identifier for this wiki instance (required for multi-tenant MCP).
      *
      * @return string Non-empty wiki identifier

--- a/includes/Hooks/AutoEmbeddingHooks.php
+++ b/includes/Hooks/AutoEmbeddingHooks.php
@@ -23,16 +23,7 @@ use Psr\Log\LoggerInterface;
 class AutoEmbeddingHooks
 {
     /**
-     * Fired after a successful page save (edit, new page, or null edit).
-     *
      * @see https://www.mediawiki.org/wiki/Manual:Hooks/PageSaveComplete
-     *
-     * @param \WikiPage $wikiPage
-     * @param UserIdentity $user
-     * @param string $summary
-     * @param int $flags
-     * @param RevisionRecord $revisionRecord
-     * @param mixed $editResult
      */
     public static function onPageSaveComplete(
         $wikiPage,
@@ -55,15 +46,7 @@ class AutoEmbeddingHooks
     }
 
     /**
-     * Fired after a page is deleted.
-     *
-     * @param \MediaWiki\Page\ProperPageIdentity $page
-     * @param UserIdentity $user
-     * @param string $reason
-     * @param int $id
-     * @param mixed $content
-     * @param mixed $logEntry
-     * @param bool $archived
+     * @see https://www.mediawiki.org/wiki/Manual:Hooks/PageDeleteComplete
      */
     public static function onPageDeleteComplete(
         $page,
@@ -87,17 +70,8 @@ class AutoEmbeddingHooks
     }
 
     /**
-     * Fired after a page move. The old title's embeddings need to be dropped
-     * (they're keyed on title, so they'd otherwise become orphans referring
-     * to a non-existent page) and the new title needs to be re-embedded.
-     *
-     * @param PageIdentity $old
-     * @param PageIdentity $new
-     * @param UserIdentity $user
-     * @param int $pageid
-     * @param int $redirid
-     * @param string $reason
-     * @param \MediaWiki\Revision\RevisionRecord $revision
+     * Embeddings are keyed on title, so a move would otherwise leave the old
+     * title's vectors orphaned — drop them and re-embed under the new title.
      */
     public static function onPageMoveComplete(
         PageIdentity $old,

--- a/includes/Hooks/AutoEmbeddingHooks.php
+++ b/includes/Hooks/AutoEmbeddingHooks.php
@@ -124,12 +124,19 @@ class AutoEmbeddingHooks
     }
 
     /**
-     * Skip talk pages and user pages to avoid embedding huge volumes
-     * of irrelevant content.
+     * Decide whether a title is excluded from embedding by config.
+     *
+     * Defaults match the historical behavior (skip talk pages and NS_USER) but
+     * are overridable via $wgMWAssistantEmbedSkipNamespaces and
+     * $wgMWAssistantEmbedTalkPages, e.g. for research wikis where user pages
+     * carry valuable content.
      */
     private static function shouldSkipTitle(Title $title): bool
     {
-        return $title->isTalkPage() || $title->getNamespace() === NS_USER;
+        if ($title->isTalkPage() && !Config::shouldEmbedTalkPages()) {
+            return true;
+        }
+        return in_array($title->getNamespace(), Config::getEmbedSkipNamespaces(), true);
     }
 
     private static function enqueueUpdate(Title $title): void

--- a/includes/Hooks/AutoEmbeddingHooks.php
+++ b/includes/Hooks/AutoEmbeddingHooks.php
@@ -2,23 +2,26 @@
 
 namespace MWAssistant\Hooks;
 
-use MediaWiki\Content\ContentHandler;
 use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Page\PageIdentity;
 use MediaWiki\Revision\RevisionRecord;
-use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Title\Title;
 use MediaWiki\User\UserIdentity;
 use MWAssistant\Config;
-use MWAssistant\MCP\EmbeddingsClient;
+use MWAssistant\Jobs\DeleteEmbeddingJob;
+use MWAssistant\Jobs\UpdateEmbeddingJob;
 use Psr\Log\LoggerInterface;
 
 /**
- * Automatically updates or deletes embeddings on the MCP server
- * whenever a page is saved or removed.
+ * Hooks that translate page lifecycle events into embedding-update/delete jobs.
+ *
+ * The hooks themselves are deliberately tiny: they only enqueue. All MCP I/O
+ * happens in the job runner so page saves don't block on network latency and
+ * MCP outages don't surface as save errors.
  */
 class AutoEmbeddingHooks
 {
-
     /**
      * Fired after a successful page save (edit, new page, or null edit).
      *
@@ -48,28 +51,7 @@ class AutoEmbeddingHooks
             return;
         }
 
-        $content = $revisionRecord->getContent(SlotRecord::MAIN);
-        if (!$content) {
-            return;
-        }
-
-        $text = ContentHandler::getContentText($content);
-        if (!is_string($text) || trim($text) === '') {
-            return;
-        }
-
-        $pageTitle = $title->getPrefixedText();
-        self::runEmbeddingOp(
-            'update',
-            $pageTitle,
-            fn (EmbeddingsClient $c) => $c->updatePage(
-                $user,
-                $pageTitle,
-                $text,
-                $title->getNamespace(),
-                $revisionRecord->getTimestamp()
-            )
-        );
+        self::enqueueUpdate($title);
     }
 
     /**
@@ -101,12 +83,44 @@ class AutoEmbeddingHooks
             return;
         }
 
-        $pageTitle = $title->getPrefixedText();
-        self::runEmbeddingOp(
-            'delete',
-            $pageTitle,
-            fn (EmbeddingsClient $c) => $c->deletePage($user, $pageTitle)
-        );
+        self::enqueueDelete($title);
+    }
+
+    /**
+     * Fired after a page move. The old title's embeddings need to be dropped
+     * (they're keyed on title, so they'd otherwise become orphans referring
+     * to a non-existent page) and the new title needs to be re-embedded.
+     *
+     * @param PageIdentity $old
+     * @param PageIdentity $new
+     * @param UserIdentity $user
+     * @param int $pageid
+     * @param int $redirid
+     * @param string $reason
+     * @param \MediaWiki\Revision\RevisionRecord $revision
+     */
+    public static function onPageMoveComplete(
+        PageIdentity $old,
+        PageIdentity $new,
+        UserIdentity $user,
+        int $pageid,
+        int $redirid,
+        string $reason,
+        $revision
+    ): void {
+        if (!Config::isAutoEmbedEnabled()) {
+            return;
+        }
+
+        $oldTitle = Title::newFromPageIdentity($old);
+        $newTitle = Title::newFromPageIdentity($new);
+
+        if ($oldTitle && !self::shouldSkipTitle($oldTitle)) {
+            self::enqueueDelete($oldTitle);
+        }
+        if ($newTitle && !self::shouldSkipTitle($newTitle)) {
+            self::enqueueUpdate($newTitle);
+        }
     }
 
     /**
@@ -118,39 +132,37 @@ class AutoEmbeddingHooks
         return $title->isTalkPage() || $title->getNamespace() === NS_USER;
     }
 
-    /**
-     * Execute an embedding operation and log success / failure consistently.
-     *
-     * @param string $op Operation label used in log messages ("update" / "delete").
-     * @param string $pageTitle Page being operated on (for log context).
-     * @param callable $callback Receives an EmbeddingsClient and returns its response array.
-     */
-    private static function runEmbeddingOp(string $op, string $pageTitle, callable $callback): void
+    private static function enqueueUpdate(Title $title): void
     {
-        $logger = self::logger();
-        $client = new EmbeddingsClient();
-
         try {
-            $res = $callback($client);
-            if (isset($res['error'])) {
-                $logger->error('AutoEmbed {op} failed for {page}: {error}', [
-                    'op' => $op,
-                    'page' => $pageTitle,
-                    'error' => $res['message'] ?? 'Unknown error',
-                ]);
-            } else {
-                $logger->debug('AutoEmbed {op} success for {page}', [
-                    'op' => $op,
-                    'page' => $pageTitle,
-                ]);
-            }
+            self::jobQueue()->push(new UpdateEmbeddingJob($title));
         } catch (\Throwable $e) {
-            $logger->error('AutoEmbed {op} exception for {page}: {error}', [
-                'op' => $op,
-                'page' => $pageTitle,
-                'error' => $e->getMessage(),
+            self::logger()->error('Failed to enqueue UpdateEmbeddingJob for {title}: {err}', [
+                'title' => $title->getPrefixedText(),
+                'err' => $e->getMessage(),
             ]);
         }
+    }
+
+    private static function enqueueDelete(Title $title): void
+    {
+        try {
+            // Capture the prefixed title in params: by the time the job runs,
+            // the on-wiki Title may resolve differently (e.g. after a move).
+            self::jobQueue()->push(new DeleteEmbeddingJob($title, [
+                'prefixed_title' => $title->getPrefixedText(),
+            ]));
+        } catch (\Throwable $e) {
+            self::logger()->error('Failed to enqueue DeleteEmbeddingJob for {title}: {err}', [
+                'title' => $title->getPrefixedText(),
+                'err' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private static function jobQueue()
+    {
+        return MediaWikiServices::getInstance()->getJobQueueGroup();
     }
 
     private static function logger(): LoggerInterface

--- a/includes/HttpClient.php
+++ b/includes/HttpClient.php
@@ -127,8 +127,15 @@ class HttpClient
         // Transport-level execution (network/HTTP)
         $status = $req->execute();
 
-        // Network-level error (connection failed, DNS, timeout, etc.)
-        if (!$status instanceof StatusValue || !$status->isOK()) {
+        // MWHttpRequest reports any non-2xx as a non-OK StatusValue, which
+        // makes 4xx/5xx look like transport failures. Pull the HTTP code
+        // and body up front so we can distinguish "no response at all"
+        // (real transport failure) from "server replied with an error"
+        // (whose body usually carries the validation detail we need).
+        $httpCode = $req->getStatus();
+        $bodyRaw = $req->getContent();
+
+        if ($httpCode === 0) {
             $err = $status instanceof StatusValue
                 ? $status->getWikiText()
                 : 'Unknown HTTP transport failure';
@@ -144,9 +151,6 @@ class HttpClient
                 'body' => "Transport error: {$err}",
             ];
         }
-
-        $httpCode = $req->getStatus();
-        $bodyRaw = $req->getContent();
 
         // Normalize body to UTF-8 to avoid JSON decode crashes
         $bodyRaw = is_string($bodyRaw)

--- a/includes/Jobs/DeleteEmbeddingJob.php
+++ b/includes/Jobs/DeleteEmbeddingJob.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace MWAssistant\Jobs;
+
+use Job;
+use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
+use MWAssistant\Config;
+use MWAssistant\MCP\EmbeddingsClient;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Background job: tell the MCP server to drop all embeddings for a page.
+ *
+ * The original prefixed title is carried via params['prefixed_title'] because
+ * by the time the job runs the local Title may already be gone (delete) or
+ * point to a different page (move). We always send the title that was current
+ * at the moment of enqueue.
+ */
+class DeleteEmbeddingJob extends Job
+{
+    public const TYPE = 'mwassistantDeleteEmbedding';
+
+    public function __construct(Title $title, array $params = [])
+    {
+        parent::__construct(self::TYPE, $title, $params);
+        $this->removeDuplicates = true;
+    }
+
+    public function run(): bool
+    {
+        $logger = $this->logger();
+        $prefixedTitle = $this->params['prefixed_title']
+            ?? ($this->getTitle() ? $this->getTitle()->getPrefixedText() : null);
+
+        if (!$prefixedTitle) {
+            $logger->warning('DeleteEmbeddingJob: missing title, dropping');
+            return true;
+        }
+
+        try {
+            $client = new EmbeddingsClient();
+            $res = $client->deletePage(
+                User::newSystemUser('MWAssistant Embedder', ['steal' => true]),
+                $prefixedTitle
+            );
+
+            if (isset($res['error'])) {
+                $msg = $res['message'] ?? 'embedding delete failed';
+                $logger->warning('DeleteEmbeddingJob {title} -> server error: {err}', [
+                    'title' => $prefixedTitle,
+                    'err' => $msg,
+                ]);
+                $this->setLastError($msg);
+                return false;
+            }
+
+            return true;
+        } catch (Throwable $e) {
+            $logger->error('DeleteEmbeddingJob exception for {title}: {err}', [
+                'title' => $prefixedTitle,
+                'err' => $e->getMessage(),
+            ]);
+            $this->setLastError($e->getMessage());
+            return false;
+        }
+    }
+
+    private function logger(): LoggerInterface
+    {
+        return LoggerFactory::getInstance(Config::LOGGER_CHANNEL);
+    }
+}

--- a/includes/Jobs/DeleteEmbeddingJob.php
+++ b/includes/Jobs/DeleteEmbeddingJob.php
@@ -2,13 +2,8 @@
 
 namespace MWAssistant\Jobs;
 
-use Job;
-use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\Title\Title;
-use MediaWiki\User\User;
-use MWAssistant\Config;
 use MWAssistant\MCP\EmbeddingsClient;
-use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
@@ -19,7 +14,7 @@ use Throwable;
  * point to a different page (move). We always send the title that was current
  * at the moment of enqueue.
  */
-class DeleteEmbeddingJob extends Job
+class DeleteEmbeddingJob extends EmbeddingJobBase
 {
     public const TYPE = 'mwassistantDeleteEmbedding';
 
@@ -42,30 +37,16 @@ class DeleteEmbeddingJob extends Job
 
         try {
             $client = new EmbeddingsClient();
-            $res = $client->deletePage(
-                User::newSystemUser('MWAssistant Embedder', ['steal' => true]),
-                $prefixedTitle
-            );
+            $res = $client->deletePage($this->resolveSystemUser(), $prefixedTitle);
 
             if (isset($res['error'])) {
-                $status = (int) ($res['status'] ?? 0);
-                $msg = $res['message'] ?? 'embedding delete failed';
-                $isPermanent = $status >= 400 && $status < 500 && $status !== 429;
-                if ($isPermanent) {
-                    $logger->error(
-                        'DeleteEmbeddingJob {title} -> permanent failure ({status}); dropping job: {err}',
-                        ['title' => $prefixedTitle, 'status' => $status, 'err' => $msg]
-                    );
-                    return true;
-                }
-                $logger->warning(
-                    'DeleteEmbeddingJob {title} -> transient failure ({status}); will retry: {err}',
-                    ['title' => $prefixedTitle, 'status' => $status, 'err' => $msg]
+                return $this->classifyClientError(
+                    $logger,
+                    'DeleteEmbeddingJob',
+                    $prefixedTitle,
+                    $res
                 );
-                $this->setLastError($msg);
-                return false;
             }
-
             return true;
         } catch (Throwable $e) {
             $logger->error('DeleteEmbeddingJob exception for {title}: {err}', [
@@ -75,10 +56,5 @@ class DeleteEmbeddingJob extends Job
             $this->setLastError($e->getMessage());
             return false;
         }
-    }
-
-    private function logger(): LoggerInterface
-    {
-        return LoggerFactory::getInstance(Config::LOGGER_CHANNEL);
     }
 }

--- a/includes/Jobs/DeleteEmbeddingJob.php
+++ b/includes/Jobs/DeleteEmbeddingJob.php
@@ -48,11 +48,20 @@ class DeleteEmbeddingJob extends Job
             );
 
             if (isset($res['error'])) {
+                $status = (int) ($res['status'] ?? 0);
                 $msg = $res['message'] ?? 'embedding delete failed';
-                $logger->warning('DeleteEmbeddingJob {title} -> server error: {err}', [
-                    'title' => $prefixedTitle,
-                    'err' => $msg,
-                ]);
+                $isPermanent = $status >= 400 && $status < 500 && $status !== 429;
+                if ($isPermanent) {
+                    $logger->error(
+                        'DeleteEmbeddingJob {title} -> permanent failure ({status}); dropping job: {err}',
+                        ['title' => $prefixedTitle, 'status' => $status, 'err' => $msg]
+                    );
+                    return true;
+                }
+                $logger->warning(
+                    'DeleteEmbeddingJob {title} -> transient failure ({status}); will retry: {err}',
+                    ['title' => $prefixedTitle, 'status' => $status, 'err' => $msg]
+                );
                 $this->setLastError($msg);
                 return false;
             }

--- a/includes/Jobs/EmbeddingJobBase.php
+++ b/includes/Jobs/EmbeddingJobBase.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace MWAssistant\Jobs;
+
+use Job;
+use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\User\User;
+use MWAssistant\Config;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Shared scaffolding for jobs that talk to the MCP embeddings API.
+ *
+ * Centralizes the system-user lookup (jobs run outside any web request, so
+ * there's no live UserIdentity) and the 4xx-vs-5xx error classification so
+ * UpdateEmbeddingJob and DeleteEmbeddingJob aren't drifting copies of each
+ * other.
+ */
+abstract class EmbeddingJobBase extends Job
+{
+    /**
+     * Resolve the system user used to mint MCP JWTs for service-to-service
+     * embedding operations. The MCP server doesn't track per-user state for
+     * these calls — the user identity exists only to satisfy the JWT scope.
+     */
+    protected function resolveSystemUser(): User
+    {
+        return User::newSystemUser(Config::SYSTEM_USER_NAME, ['steal' => true]);
+    }
+
+    /**
+     * Decide whether an EmbeddingsClient error response should retry.
+     *
+     * 4xx (other than 429) means the request itself is malformed — retrying
+     * with the same payload will keep failing, so we drop the job loudly and
+     * leave humans to investigate via the ERROR log line. 5xx, 429, and
+     * transport-level failures are transient: the JobQueue will retry.
+     *
+     * @param array{status?:int|null,message?:string} $res
+     * @return bool true to drop the job (job-complete), false to retry.
+     */
+    protected function classifyClientError(
+        LoggerInterface $logger,
+        string $jobName,
+        string $title,
+        array $res
+    ): bool {
+        $status = (int) ($res['status'] ?? 0);
+        $msg = $res['message'] ?? 'embedding operation failed';
+
+        $isPermanent = $status >= 400 && $status < 500 && $status !== 429;
+
+        if ($isPermanent) {
+            $logger->error(
+                '{job} {title} -> permanent failure ({status}); dropping job: {err}',
+                ['job' => $jobName, 'title' => $title, 'status' => $status, 'err' => $msg]
+            );
+            return true;
+        }
+
+        $logger->warning(
+            '{job} {title} -> transient failure ({status}); will retry: {err}',
+            ['job' => $jobName, 'title' => $title, 'status' => $status, 'err' => $msg]
+        );
+        $this->setLastError($msg);
+        return false;
+    }
+
+    protected function logger(): LoggerInterface
+    {
+        return LoggerFactory::getInstance(Config::LOGGER_CHANNEL);
+    }
+}

--- a/includes/Jobs/UpdateEmbeddingJob.php
+++ b/includes/Jobs/UpdateEmbeddingJob.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace MWAssistant\Jobs;
+
+use Job;
+use MediaWiki\Content\ContentHandler;
+use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
+use MWAssistant\Config;
+use MWAssistant\MCP\EmbeddingsClient;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Background job: re-embed a page on the MCP server.
+ *
+ * Replaces the synchronous HTTP call that used to happen inside the page-save
+ * hook and the dashboard's batch-update loop. Doing this in a job means:
+ *  - page saves no longer block on MCP latency,
+ *  - bulk re-embeds aren't bounded by PHP's max_execution_time,
+ *  - failures retry automatically with backoff (the JobQueue's normal behavior),
+ *  - duplicate enqueues collapse via removeDuplicates.
+ */
+class UpdateEmbeddingJob extends Job
+{
+    public const TYPE = 'mwassistantUpdateEmbedding';
+
+    public function __construct(Title $title, array $params = [])
+    {
+        parent::__construct(self::TYPE, $title, $params);
+        // Two saves landing back-to-back should produce one re-embed, not two.
+        $this->removeDuplicates = true;
+    }
+
+    public function run(): bool
+    {
+        $logger = $this->logger();
+        $title = $this->getTitle();
+        if (!$title) {
+            $logger->warning('UpdateEmbeddingJob: missing title, dropping');
+            return true;
+        }
+
+        try {
+            $services = MediaWikiServices::getInstance();
+            $wikiPage = $services->getWikiPageFactory()->newFromTitle($title);
+            $content = $wikiPage->getContent();
+            if (!$content) {
+                // Page exists but has no current revision (deleted between
+                // enqueue and run); nothing to embed. Drop the job rather
+                // than retry — the situation won't fix itself.
+                return true;
+            }
+
+            $text = ContentHandler::getContentText($content);
+            if (!is_string($text) || trim($text) === '') {
+                return true;
+            }
+
+            $revId = $wikiPage->getLatest() ?: null;
+            $timestamp = $wikiPage->getTimestamp();
+
+            $client = new EmbeddingsClient();
+            $res = $client->updatePage(
+                $this->resolveUser(),
+                $title->getPrefixedText(),
+                $text,
+                $title->getNamespace(),
+                $timestamp,
+                $revId
+            );
+
+            if (isset($res['error'])) {
+                $msg = $res['message'] ?? 'embedding update failed';
+                $logger->warning('UpdateEmbeddingJob {title} -> server error: {err}', [
+                    'title' => $title->getPrefixedText(),
+                    'err' => $msg,
+                ]);
+                $this->setLastError($msg);
+                return false;  // triggers retry with backoff
+            }
+
+            $logger->debug('UpdateEmbeddingJob {title} -> queued on MCP', [
+                'title' => $title->getPrefixedText(),
+            ]);
+            return true;
+        } catch (Throwable $e) {
+            $logger->error('UpdateEmbeddingJob exception for {title}: {err}', [
+                'title' => $title->getPrefixedText(),
+                'err' => $e->getMessage(),
+            ]);
+            $this->setLastError($e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Jobs run outside any web request, so there's no live UserIdentity. We use
+     * a dedicated system user — its only role is to mint the JWT carrying the
+     * 'embeddings' scope; the MCP server doesn't track per-user state for these
+     * service-to-service calls.
+     */
+    private function resolveUser(): User
+    {
+        return User::newSystemUser('MWAssistant Embedder', ['steal' => true]);
+    }
+
+    private function logger(): LoggerInterface
+    {
+        return LoggerFactory::getInstance(Config::LOGGER_CHANNEL);
+    }
+}

--- a/includes/Jobs/UpdateEmbeddingJob.php
+++ b/includes/Jobs/UpdateEmbeddingJob.php
@@ -2,15 +2,10 @@
 
 namespace MWAssistant\Jobs;
 
-use Job;
 use MediaWiki\Content\ContentHandler;
-use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
-use MediaWiki\User\User;
-use MWAssistant\Config;
 use MWAssistant\MCP\EmbeddingsClient;
-use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
@@ -20,10 +15,10 @@ use Throwable;
  * hook and the dashboard's batch-update loop. Doing this in a job means:
  *  - page saves no longer block on MCP latency,
  *  - bulk re-embeds aren't bounded by PHP's max_execution_time,
- *  - failures retry automatically with backoff (the JobQueue's normal behavior),
+ *  - failures retry automatically with backoff,
  *  - duplicate enqueues collapse via removeDuplicates.
  */
-class UpdateEmbeddingJob extends Job
+class UpdateEmbeddingJob extends EmbeddingJobBase
 {
     public const TYPE = 'mwassistantUpdateEmbedding';
 
@@ -49,8 +44,8 @@ class UpdateEmbeddingJob extends Job
             $content = $wikiPage->getContent();
             if (!$content) {
                 // Page exists but has no current revision (deleted between
-                // enqueue and run); nothing to embed. Drop the job rather
-                // than retry — the situation won't fix itself.
+                // enqueue and run); nothing to embed. Drop rather than retry —
+                // the situation won't fix itself.
                 return true;
             }
 
@@ -59,22 +54,20 @@ class UpdateEmbeddingJob extends Job
                 return true;
             }
 
-            $revId = $wikiPage->getLatest() ?: null;
-            $timestamp = $wikiPage->getTimestamp();
-
             $client = new EmbeddingsClient();
             $res = $client->updatePage(
-                $this->resolveUser(),
+                $this->resolveSystemUser(),
                 $title->getPrefixedText(),
                 $text,
                 $title->getNamespace(),
-                $timestamp,
-                $revId
+                $wikiPage->getTimestamp(),
+                $wikiPage->getLatest() ?: null
             );
 
             if (isset($res['error'])) {
-                return $this->handleClientError(
+                return $this->classifyClientError(
                     $logger,
+                    'UpdateEmbeddingJob',
                     $title->getPrefixedText(),
                     $res
                 );
@@ -92,57 +85,5 @@ class UpdateEmbeddingJob extends Job
             $this->setLastError($e->getMessage());
             return false;
         }
-    }
-
-    /**
-     * Jobs run outside any web request, so there's no live UserIdentity. We use
-     * a dedicated system user — its only role is to mint the JWT carrying the
-     * 'embeddings' scope; the MCP server doesn't track per-user state for these
-     * service-to-service calls.
-     */
-    private function resolveUser(): User
-    {
-        return User::newSystemUser('MWAssistant Embedder', ['steal' => true]);
-    }
-
-    /**
-     * Decide whether a server error from EmbeddingsClient should be retried.
-     *
-     * 4xx (other than 429) is the server telling us the request itself is
-     * wrong — retrying with the same payload will fail the same way. Drop the
-     * job loudly and let humans investigate. 5xx, 429, and transport errors
-     * are transient by nature: backoff and retry.
-     *
-     * @param array{status?:int|null,message?:string} $res
-     */
-    private function handleClientError(LoggerInterface $logger, string $title, array $res): bool
-    {
-        $status = (int) ($res['status'] ?? 0);
-        $msg = $res['message'] ?? 'embedding update failed';
-
-        $isPermanent = $status >= 400 && $status < 500 && $status !== 429;
-
-        if ($isPermanent) {
-            $logger->error(
-                'UpdateEmbeddingJob {title} -> permanent failure ({status}); dropping job: {err}',
-                ['title' => $title, 'status' => $status, 'err' => $msg]
-            );
-            // Returning true marks the job complete so MW removes it. The
-            // ERROR log is the dead-letter signal — searchable by the title
-            // and the status code.
-            return true;
-        }
-
-        $logger->warning(
-            'UpdateEmbeddingJob {title} -> transient failure ({status}); will retry: {err}',
-            ['title' => $title, 'status' => $status, 'err' => $msg]
-        );
-        $this->setLastError($msg);
-        return false;
-    }
-
-    private function logger(): LoggerInterface
-    {
-        return LoggerFactory::getInstance(Config::LOGGER_CHANNEL);
     }
 }

--- a/includes/Jobs/UpdateEmbeddingJob.php
+++ b/includes/Jobs/UpdateEmbeddingJob.php
@@ -73,13 +73,11 @@ class UpdateEmbeddingJob extends Job
             );
 
             if (isset($res['error'])) {
-                $msg = $res['message'] ?? 'embedding update failed';
-                $logger->warning('UpdateEmbeddingJob {title} -> server error: {err}', [
-                    'title' => $title->getPrefixedText(),
-                    'err' => $msg,
-                ]);
-                $this->setLastError($msg);
-                return false;  // triggers retry with backoff
+                return $this->handleClientError(
+                    $logger,
+                    $title->getPrefixedText(),
+                    $res
+                );
             }
 
             $logger->debug('UpdateEmbeddingJob {title} -> queued on MCP', [
@@ -105,6 +103,42 @@ class UpdateEmbeddingJob extends Job
     private function resolveUser(): User
     {
         return User::newSystemUser('MWAssistant Embedder', ['steal' => true]);
+    }
+
+    /**
+     * Decide whether a server error from EmbeddingsClient should be retried.
+     *
+     * 4xx (other than 429) is the server telling us the request itself is
+     * wrong — retrying with the same payload will fail the same way. Drop the
+     * job loudly and let humans investigate. 5xx, 429, and transport errors
+     * are transient by nature: backoff and retry.
+     *
+     * @param array{status?:int|null,message?:string} $res
+     */
+    private function handleClientError(LoggerInterface $logger, string $title, array $res): bool
+    {
+        $status = (int) ($res['status'] ?? 0);
+        $msg = $res['message'] ?? 'embedding update failed';
+
+        $isPermanent = $status >= 400 && $status < 500 && $status !== 429;
+
+        if ($isPermanent) {
+            $logger->error(
+                'UpdateEmbeddingJob {title} -> permanent failure ({status}); dropping job: {err}',
+                ['title' => $title, 'status' => $status, 'err' => $msg]
+            );
+            // Returning true marks the job complete so MW removes it. The
+            // ERROR log is the dead-letter signal — searchable by the title
+            // and the status code.
+            return true;
+        }
+
+        $logger->warning(
+            'UpdateEmbeddingJob {title} -> transient failure ({status}); will retry: {err}',
+            ['title' => $title, 'status' => $status, 'err' => $msg]
+        );
+        $this->setLastError($msg);
+        return false;
     }
 
     private function logger(): LoggerInterface

--- a/includes/MCP/EmbeddingsClient.php
+++ b/includes/MCP/EmbeddingsClient.php
@@ -30,17 +30,9 @@ class EmbeddingsClient
     /**
      * Create or update embeddings for a given page.
      *
-     * @param UserIdentity $user
-     * @param string $title
-     * @param string $content
-     * @param int $namespace
-     * @param string|null $timestamp Last-modified timestamp (optional)
-     * @param int|null $revisionId MediaWiki revision ID this content was taken from.
-     *                             When supplied, the dashboard can compare against
-     *                             page_latest exactly, avoiding the false-outdated
-     *                             reports caused by page_touched cache invalidations.
-     *
-     * @return array
+     * $revisionId, when supplied, lets the dashboard compare embedding sync
+     * against page_latest exactly — avoiding the false-outdated reports
+     * caused by page_touched cache invalidations.
      */
     public function updatePage(
         UserIdentity $user,
@@ -71,11 +63,6 @@ class EmbeddingsClient
 
     /**
      * Delete embeddings for a given page title.
-     *
-     * @param UserIdentity $user
-     * @param string $title
-     *
-     * @return array
      */
     public function deletePage(UserIdentity $user, string $title): array
     {
@@ -89,9 +76,6 @@ class EmbeddingsClient
 
     /**
      * Fetch basic embeddings index statistics.
-     *
-     * @param UserIdentity $user
-     * @return array
      */
     public function getStats(UserIdentity $user): array
     {

--- a/includes/MCP/EmbeddingsClient.php
+++ b/includes/MCP/EmbeddingsClient.php
@@ -35,6 +35,10 @@ class EmbeddingsClient
      * @param string $content
      * @param int $namespace
      * @param string|null $timestamp Last-modified timestamp (optional)
+     * @param int|null $revisionId MediaWiki revision ID this content was taken from.
+     *                             When supplied, the dashboard can compare against
+     *                             page_latest exactly, avoiding the false-outdated
+     *                             reports caused by page_touched cache invalidations.
      *
      * @return array
      */
@@ -43,7 +47,8 @@ class EmbeddingsClient
         string $title,
         string $content,
         int $namespace = 0,
-        ?string $timestamp = null
+        ?string $timestamp = null,
+        ?int $revisionId = null
     ): array {
         $jwt = $this->createToken($user);
 
@@ -53,6 +58,12 @@ class EmbeddingsClient
             'namespace' => $namespace,
             'last_modified' => $timestamp,
         ];
+        // Treat 0 as "no rev id known" — page_latest can momentarily be 0 on
+        // pages that haven't been indexed by the revision table. The server
+        // requires rev_id >= 1, so sending 0 would fail validation.
+        if ($revisionId !== null && $revisionId > 0) {
+            $payload['rev_id'] = $revisionId;
+        }
 
         $resp = $this->client->postJson('/embeddings/page', $payload, $jwt);
         return $this->client->handleResponse($resp, 'embeddings update');

--- a/includes/Special/SpecialMWAssistantEmbeddings.php
+++ b/includes/Special/SpecialMWAssistantEmbeddings.php
@@ -29,11 +29,26 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
     /** @var MediaWikiServices */
     private $services;
 
+    /** Per-request cache for the MCP stats payload — kept so submit-then-render
+     *  doesn't issue two round-trips to MCP. */
+    private ?array $cachedStats = null;
+
     public function __construct()
     {
         parent::__construct('MWAssistantEmbeddings', 'mwassistant-use');
         $this->client = new EmbeddingsClient();
         $this->services = MediaWikiServices::getInstance();
+    }
+
+    /**
+     * Fetch (and memoize) MCP embedding stats for this request.
+     */
+    private function getStatsCached(): array
+    {
+        if ($this->cachedStats === null) {
+            $this->cachedStats = $this->client->getStats($this->getUser());
+        }
+        return $this->cachedStats;
     }
 
     /**
@@ -89,7 +104,7 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
         $user = $this->getUser();
 
         try {
-            $stats = $this->client->getStats($user);
+            $stats = $this->getStatsCached();
             $mcpTimestamps = $stats['page_timestamps'] ?? [];
             $mcpRevisions = $stats['page_revisions'] ?? [];
 
@@ -302,7 +317,7 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
         $user = $this->getUser();
 
         try {
-            $stats = $this->client->getStats($user);
+            $stats = $this->getStatsCached();
             $error = isset($stats['error']);
             $mcpTimestamps = $error ? [] : ($stats['page_timestamps'] ?? []);
             $mcpRevisions = $error ? [] : ($stats['page_revisions'] ?? []);

--- a/includes/Special/SpecialMWAssistantEmbeddings.php
+++ b/includes/Special/SpecialMWAssistantEmbeddings.php
@@ -2,12 +2,12 @@
 
 namespace MWAssistant\Special;
 
-use MediaWiki\Content\ContentHandler;
 use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\Title\Title;
 use MediaWiki\Widget\TitleInputWidget;
+use MWAssistant\Jobs\UpdateEmbeddingJob;
 use MWAssistant\MCP\EmbeddingsClient;
 
 /**
@@ -43,9 +43,11 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
     {
         $this->checkPermissions();
 
+        $this->setHeaders();
+
         $request = $this->getRequest();
         $output = $this->getOutput();
-        $output->setPageTitle('Vector Embeddings Status');
+        $output->setPageTitle($this->msg('mwassistantembeddings-pagetitle')->text());
 
         // Widgets + RL modules
         $output->addModules([
@@ -89,72 +91,165 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
         try {
             $stats = $this->client->getStats($user);
             $mcpTimestamps = $stats['page_timestamps'] ?? [];
+            $mcpRevisions = $stats['page_revisions'] ?? [];
 
-            $dbr = $this->services->getDBLoadBalancer()->getConnection(DB_REPLICA);
-            $rows = $dbr->newSelectQueryBuilder()
-                ->select(['page_id', 'page_namespace', 'page_title', 'page_touched'])
-                ->from('page')
-                ->where([
-                    'page_namespace' => $namespace,
-                    'page_is_redirect' => 0,
-                ])
-                ->caller(__METHOD__)
-                ->fetchResultSet();
+            $rows = $this->fetchPagesWithRevision($namespace);
 
-            $updated = 0;
+            $jobQueue = $this->services->getJobQueueGroup();
+            $jobs = [];
             $skipped = 0;
-            $errors = 0;
-            $lastErr = null;
-
-            set_time_limit(0);
 
             foreach ($rows as $row) {
                 $titleObj = Title::newFromRow($row);
                 $prefixed = $titleObj->getPrefixedText();
-                $mwTouched = $row->page_touched;
+                $pageLatest = (int) $row->page_latest;
+                $revTimestamp = $row->rev_timestamp ?? $row->page_touched;
 
-                $needsUpdate = !isset($mcpTimestamps[$prefixed]) ||
-                    $mcpTimestamps[$prefixed] < $mwTouched;
-
-                if (!$needsUpdate) {
+                if (
+                    !$this->pageIsOutdated(
+                        $prefixed,
+                        $pageLatest,
+                        $revTimestamp,
+                        $mcpRevisions,
+                        $mcpTimestamps
+                    )
+                ) {
                     $skipped++;
                     continue;
                 }
 
-                $wikiPage = $this->services->getWikiPageFactory()->newFromTitle($titleObj);
-                $content = $wikiPage->getContent();
-                $text = $content ? ContentHandler::getContentText($content) : '';
-
-                if (!$text) {
-                    $skipped++;
-                    continue;
-                }
-
-                // $row->page_namespace is a string from DB, cast to int
-                $nsId = (int) $row->page_namespace;
-
-                $updateRes = $this->client->updatePage($user, $prefixed, $text, $nsId, $mwTouched);
-                if (isset($updateRes['error'])) {
-                    $errors++;
-                    $lastErr = $updateRes['message'];
-                } else {
-                    $updated++;
-                }
+                $jobs[] = new UpdateEmbeddingJob($titleObj);
             }
 
-            $msg = "Batch processed for namespace $namespace.<br>" .
-                "Updated: <b>$updated</b><br>" .
-                "Skipped: $skipped<br>" .
-                "Errors: $errors" .
-                ($errors && $lastErr ? "<br>Last Error: " . htmlspecialchars($lastErr) : "");
+            if ($jobs) {
+                // push() handles batches efficiently — single round-trip to the queue.
+                $jobQueue->push($jobs);
+            }
 
-            $output->addHTML(Html::successBox($msg));
+            $queued = count($jobs);
+            $this->renderBatchQueuedBanner($namespace, $queued, $skipped);
 
         } catch (\Exception $e) {
             $output->addHTML(
                 Html::errorBox("Batch update failed: " . htmlspecialchars($e->getMessage()))
             );
         }
+    }
+
+    /**
+     * Render a "queued" banner after a batch enqueue. Server-rendered only —
+     * we intentionally avoid auto-refresh; the user reloads when they want
+     * to check progress.
+     */
+    private function renderBatchQueuedBanner(int $namespace, int $queued, int $skipped): void
+    {
+        $output = $this->getOutput();
+
+        if ($queued === 0) {
+            $output->addHTML(Html::successBox(
+                $this->msg('mwassistantembeddings-batch-nothing-to-do')
+                    ->numParams($skipped)
+                    ->parse()
+            ));
+            return;
+        }
+
+        $body = $this->msg('mwassistantembeddings-batch-queued')
+            ->numParams($queued, $namespace, $skipped)
+            ->parse();
+        $body .= ' ' . $this->renderReloadHint();
+        $output->addHTML(Html::rawElement(
+            'div',
+            ['class' => 'mwassistant-batch-banner'],
+            $body
+        ));
+    }
+
+    /**
+     * "Reload this page to see progress" — rendered as a same-URL anchor so
+     * keyboard / right-click flows work, instead of a JS button.
+     */
+    private function renderReloadHint(): string
+    {
+        $url = htmlspecialchars($this->getPageTitle()->getLocalURL(
+            $this->getRequest()->getQueryValuesOnly()
+        ));
+        return Html::rawElement(
+            'a',
+            [
+                'href' => $url,
+                'class' => 'mwassistant-batch-reload-link',
+            ],
+            $this->msg('mwassistantembeddings-reload-hint')->escaped()
+        );
+    }
+
+    /**
+     * Fetch pages joined with their latest revision row.
+     *
+     * page_latest is the rev_id of the page's current revision. Joining to
+     * revision lets us compare against rev_timestamp (the *content* last-modified
+     * time) instead of page_touched (which moves on cache invalidation, causing
+     * false "outdated" reports).
+     *
+     * @param int|int[]|null $namespace Single namespace, list, or null for all.
+     * @return \Wikimedia\Rdbms\IResultWrapper
+     */
+    private function fetchPagesWithRevision($namespace = null)
+    {
+        $dbr = $this->services->getDBLoadBalancer()->getConnection(DB_REPLICA);
+        $qb = $dbr->newSelectQueryBuilder()
+            ->select([
+                'page_id',
+                'page_namespace',
+                'page_title',
+                'page_touched',
+                'page_latest',
+                'page_len',
+                'rev_timestamp',
+            ])
+            ->from('page')
+            ->leftJoin('revision', null, 'page_latest = rev_id')
+            ->where(['page_is_redirect' => 0])
+            ->caller(__METHOD__);
+
+        if ($namespace !== null) {
+            $qb->andWhere(['page_namespace' => $namespace]);
+        }
+
+        return $qb->fetchResultSet();
+    }
+
+    /**
+     * Decide whether a page's stored embedding is out of date.
+     *
+     * Preferred path: compare rev_id equality (exact identity). Falls back to
+     * timestamp comparison against rev_timestamp for legacy embeddings that
+     * predate rev_id tracking — but never against page_touched, which is
+     * bumped by cache invalidations unrelated to content.
+     *
+     * @param string $prefixed Prefixed page title (the key MCP uses).
+     * @param int $pageLatest Wiki's current rev_id (page_latest).
+     * @param string|null $revTimestamp Wiki's rev_timestamp for page_latest.
+     * @param array<string,int> $mcpRevisions page_title -> stored rev_id.
+     * @param array<string,string> $mcpTimestamps page_title -> stored last_modified.
+     */
+    private function pageIsOutdated(
+        string $prefixed,
+        int $pageLatest,
+        ?string $revTimestamp,
+        array $mcpRevisions,
+        array $mcpTimestamps
+    ): bool {
+        if (isset($mcpRevisions[$prefixed])) {
+            return (int) $mcpRevisions[$prefixed] !== $pageLatest;
+        }
+        if (isset($mcpTimestamps[$prefixed]) && $revTimestamp !== null) {
+            return $mcpTimestamps[$prefixed] < $revTimestamp;
+        }
+        // Embedding has neither rev_id nor a usable timestamp recorded: treat
+        // as outdated so the next batch run reconciles it.
+        return true;
     }
 
     /* ============================================================
@@ -167,7 +262,6 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
     private function handleSingleUpdate(string $pageName)
     {
         $output = $this->getOutput();
-        $user = $this->getUser();
 
         $title = Title::newFromText($pageName);
         if (!$title || !$title->exists()) {
@@ -175,35 +269,24 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
             return;
         }
 
-        $wikiPage = $this->services->getWikiPageFactory()->newFromTitle($title);
-        $content = $wikiPage->getContent();
-        $text = $content ? ContentHandler::getContentText($content) : '';
-
-        if (!$text) {
-            $output->addHTML(Html::errorBox("No text content found for page."));
+        try {
+            $this->services->getJobQueueGroup()->push(new UpdateEmbeddingJob($title));
+        } catch (\Throwable $e) {
+            $output->addHTML(Html::errorBox(
+                "Could not queue embedding job: " . htmlspecialchars($e->getMessage())
+            ));
             return;
         }
 
-        $timestamp = $wikiPage->getTimestamp();
-        $namespace = $title->getNamespace();
-
-        $updateRes = $this->client->updatePage(
-            $user,
-            $title->getPrefixedText(),
-            $text,
-            $namespace,
-            $timestamp
-        );
-
-        if (isset($updateRes['error'])) {
-            $output->addHTML(Html::errorBox(htmlspecialchars($updateRes['message'] ?? 'Unknown error')));
-        } else {
-            $output->addHTML(
-                Html::successBox(
-                    "Successfully updated embedding for: " . htmlspecialchars($title->getPrefixedText())
-                )
-            );
-        }
+        $body = $this->msg('mwassistantembeddings-single-queued')
+            ->params($title->getPrefixedText())
+            ->parse();
+        $body .= ' ' . $this->renderReloadHint();
+        $output->addHTML(Html::rawElement(
+            'div',
+            ['class' => 'mwassistant-batch-banner'],
+            $body
+        ));
     }
 
     /* ============================================================
@@ -222,6 +305,7 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
             $stats = $this->client->getStats($user);
             $error = isset($stats['error']);
             $mcpTimestamps = $error ? [] : ($stats['page_timestamps'] ?? []);
+            $mcpRevisions = $error ? [] : ($stats['page_revisions'] ?? []);
             $totalVectors = $error ? 0 : ($stats['total_vectors'] ?? 0);
         } catch (\Exception $e) {
             $output->addHTML(Html::errorBox("Could not fetch embedding statistics: " . $e->getMessage()));
@@ -245,7 +329,7 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
         $output->addHTML('</div>');
 
         // ---- Namespace Status Table ----
-        $nsStats = $this->computeNamespaceStats($mcpTimestamps);
+        $nsStats = $this->computeNamespaceStats($mcpTimestamps, $mcpRevisions);
         $this->renderNamespaceTable($nsStats);
 
         // ---- Single Page Update Form ----
@@ -254,10 +338,12 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
 
     /**
      * Build namespace summary statistics.
+     *
+     * @param array<string,string> $mcpTimestamps page_title -> last_modified.
+     * @param array<string,int> $mcpRevisions page_title -> rev_id.
      */
-    private function computeNamespaceStats(array $mcpTimestamps): array
+    private function computeNamespaceStats(array $mcpTimestamps, array $mcpRevisions = []): array
     {
-        $dbr = $this->services->getDBLoadBalancer()->getConnection(DB_REPLICA);
         $nsInfo = $this->services->getNamespaceInfo();
         $validNS = [];
 
@@ -269,15 +355,7 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
         }
         ksort($validNS);
 
-        $res = $dbr->newSelectQueryBuilder()
-            ->select(['page_namespace', 'page_title', 'page_touched', 'page_len'])
-            ->from('page')
-            ->where([
-                'page_namespace' => array_keys($validNS),
-                'page_is_redirect' => 0,
-            ])
-            ->caller(__METHOD__)
-            ->fetchResultSet();
+        $res = $this->fetchPagesWithRevision(array_keys($validNS));
 
         $stats = [];
         foreach ($validNS as $nsId => $name) {
@@ -295,17 +373,25 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
             $nsId = (int) $row->page_namespace;
             $titleObj = Title::makeTitle($nsId, $row->page_title);
             $prefixed = $titleObj->getPrefixedText();
-            $mwTouched = $row->page_touched;
+            $pageLatest = (int) $row->page_latest;
+            $revTimestamp = $row->rev_timestamp ?? $row->page_touched;
             $pageLen = (int) $row->page_len;
 
             $stats[$nsId]['total']++;
 
-            if (isset($mcpTimestamps[$prefixed])) {
-                $stats[$nsId][
-                    $mcpTimestamps[$prefixed] >= $mwTouched ? 'synced' : 'outdated'
-                ]++;
+            $hasEmbedding = isset($mcpRevisions[$prefixed]) || isset($mcpTimestamps[$prefixed]);
+
+            if ($hasEmbedding) {
+                $bucket = $this->pageIsOutdated(
+                    $prefixed,
+                    $pageLatest,
+                    $revTimestamp,
+                    $mcpRevisions,
+                    $mcpTimestamps
+                ) ? 'outdated' : 'synced';
+                $stats[$nsId][$bucket]++;
             } else {
-                // Match server’s heuristic: skip pages too short to embed
+                // Match server's heuristic: skip pages too short to embed
                 if ($pageLen < 10) {
                     $stats[$nsId]['skipped']++;
                 } else {

--- a/includes/Special/SpecialMWAssistantEmbeddings.php
+++ b/includes/Special/SpecialMWAssistantEmbeddings.php
@@ -7,6 +7,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\Title\Title;
 use MediaWiki\Widget\TitleInputWidget;
+use MWAssistant\Jobs\DeleteEmbeddingJob;
 use MWAssistant\Jobs\UpdateEmbeddingJob;
 use MWAssistant\MCP\EmbeddingsClient;
 
@@ -142,7 +143,7 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
             }
 
             $queued = count($jobs);
-            $this->renderBatchQueuedBanner($namespace, $queued, $skipped);
+            $this->renderJustQueuedNotice($queued, $skipped);
 
         } catch (\Exception $e) {
             $output->addHTML(
@@ -152,11 +153,11 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
     }
 
     /**
-     * Render a "queued" banner after a batch enqueue. Server-rendered only —
-     * we intentionally avoid auto-refresh; the user reloads when they want
-     * to check progress.
+     * One-shot success notice rendered immediately after a batch submit.
+     * Persistent "X jobs in flight" feedback comes from the queue-driven
+     * pending banner that runs on every page render.
      */
-    private function renderBatchQueuedBanner(int $namespace, int $queued, int $skipped): void
+    private function renderJustQueuedNotice(int $queued, int $skipped): void
     {
         $output = $this->getOutput();
 
@@ -169,15 +170,46 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
             return;
         }
 
-        $body = $this->msg('mwassistantembeddings-batch-queued')
-            ->numParams($queued, $namespace, $skipped)
+        $output->addHTML(Html::successBox(
+            $this->msg('mwassistantembeddings-batch-queued')
+                ->numParams($queued, $skipped)
+                ->parse()
+        ));
+    }
+
+    /**
+     * Banner driven entirely by the JobQueue: persists across reloads as long
+     * as embedding jobs are still in flight, and disappears once the queue
+     * drains. This is what lets the user see progress without us auto-refreshing.
+     */
+    private function renderPendingJobsBanner(): void
+    {
+        $pending = $this->getPendingEmbeddingJobCount();
+        if ($pending === 0) {
+            return;
+        }
+
+        $body = $this->msg('mwassistantembeddings-jobs-pending')
+            ->numParams($pending)
             ->parse();
         $body .= ' ' . $this->renderReloadHint();
-        $output->addHTML(Html::rawElement(
+        $this->getOutput()->addHTML(Html::rawElement(
             'div',
             ['class' => 'mwassistant-batch-banner'],
             $body
         ));
+    }
+
+    private function getPendingEmbeddingJobCount(): int
+    {
+        $jobQueueGroup = $this->services->getJobQueueGroup();
+        $total = 0;
+        foreach ([UpdateEmbeddingJob::TYPE, DeleteEmbeddingJob::TYPE] as $type) {
+            $queue = $jobQueueGroup->get($type);
+            // Unclaimed (waiting) + acquired (currently being run by a runner).
+            $total += $queue->getSize() + $queue->getAcquiredCount();
+        }
+        return $total;
     }
 
     /**
@@ -293,14 +325,10 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
             return;
         }
 
-        $body = $this->msg('mwassistantembeddings-single-queued')
-            ->params($title->getPrefixedText())
-            ->parse();
-        $body .= ' ' . $this->renderReloadHint();
-        $output->addHTML(Html::rawElement(
-            'div',
-            ['class' => 'mwassistant-batch-banner'],
-            $body
+        $output->addHTML(Html::successBox(
+            $this->msg('mwassistantembeddings-single-queued')
+                ->params($title->getPrefixedText())
+                ->parse()
         ));
     }
 
@@ -315,6 +343,11 @@ class SpecialMWAssistantEmbeddings extends SpecialPage
     {
         $output = $this->getOutput();
         $user = $this->getUser();
+
+        // Persistent banner — visible on every render while jobs are in flight,
+        // gone once the queue drains. Independent of whether this request
+        // submitted anything.
+        $this->renderPendingJobsBanner();
 
         try {
             $stats = $this->getStatsCached();

--- a/resources/mwassistant.embeddings.css
+++ b/resources/mwassistant.embeddings.css
@@ -6,6 +6,25 @@
     max-width: 1200px;
 }
 
+/* Auto-refresh banner shown after a batch enqueue. Sits at the top of the
+   dashboard with a soft accent so it reads as a transient operational state
+   rather than a hard error. */
+.mwassistant-batch-banner {
+    margin: 0 0 1em;
+    padding: 12px 16px;
+    background: #eaf3ff;
+    border: 1px solid #a3c2f5;
+    border-left: 4px solid #36c;
+    border-radius: 4px;
+    line-height: 1.45;
+    color: #202122;
+}
+
+.mwassistant-batch-reload-link {
+    margin-left: 6px;
+    font-weight: 600;
+}
+
 /* Stats Cards Container */
 .mwassistant-stats-grid {
     display: grid;

--- a/resources/mwassistant.embeddings.js
+++ b/resources/mwassistant.embeddings.js
@@ -1,7 +1,14 @@
-$(function () {
-    // Infuse the TitleInputWidget to enable autocomplete
-    var $input = $('#page-input');
-    if ($input.length) {
-        OO.ui.infuse($input);
+/**
+ * MWAssistant Embeddings dashboard frontend.
+ *
+ * Only responsibility right now: infuse the OOUI TitleInputWidget so the
+ * single-page form gets autocomplete. The "queued" banner is fully
+ * server-rendered and intentionally static — the user reloads when they
+ * want fresh stats.
+ */
+$( function () {
+    var $input = $( '#page-input' );
+    if ( $input.length ) {
+        OO.ui.infuse( $input );
     }
-});
+} );

--- a/resources/mwassistant.global.css
+++ b/resources/mwassistant.global.css
@@ -1,28 +1,55 @@
-/* Container for the "Ask Assistant" shortcut button injected next to a
-   MediaWiki search input. The button is positioned below the input so it
-   never overlays the user's typed query, regardless of input width. */
+/* AI assistant shortcut icon anchored inside the search input.
+   Sits at the right edge, vertically centered, so the search-suggestion
+   dropdown that opens *below* the input never covers it. */
 .mwassistant-search-host {
     position: relative;
 }
 
-.mwassistant-search-btn {
+.mwassistant-search-icon-btn {
     position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
-    z-index: 100;
-    font-size: 0.85em;
-    line-height: 1.2;
-    padding: 4px 10px;
-    background: #fff;
-    border: 1px solid #c8ccd1;
-    border-radius: 4px;
+    top: 50%;
+    /* Leave room for the skin's own search/clear icon, which usually sits
+       at right: 4-8px. Tuned to clear Vector 2022's magnifier without
+       crowding it; falls back gracefully on Monobook/Vector legacy. */
+    right: 28px;
+    transform: translateY(-50%);
+    z-index: 5;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    border: none;
+    border-radius: 50%;
     color: #36c;
     cursor: pointer;
-    white-space: nowrap;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    opacity: 0.75;
+    transition: opacity 120ms ease, background-color 120ms ease;
 }
 
-.mwassistant-search-btn:hover {
-    background: #f8f9fa;
-    border-color: #36c;
+.mwassistant-search-icon-btn:hover,
+.mwassistant-search-icon-btn:focus {
+    opacity: 1;
+    background-color: rgba(54, 102, 204, 0.12);
+    outline: none;
+}
+
+.mwassistant-search-icon-btn:focus-visible {
+    box-shadow: 0 0 0 2px #36c;
+}
+
+.mwassistant-search-icon-btn svg {
+    display: block;
+    pointer-events: none;
+}
+
+/* On Special:Search the form is laid out wide; pin the icon to the right
+   of the actual input box rather than the form, so it stays adjacent to
+   the text the user is typing. */
+.mw-search-form-wrapper .mwassistant-search-host {
+    display: inline-block;
 }

--- a/resources/mwassistant.global.js
+++ b/resources/mwassistant.global.js
@@ -1,17 +1,22 @@
 /**
  * MWAssistant – Global "Ask Assistant" shortcut on MediaWiki search bars.
  *
- * Adds a small shortcut button that appears once a query exceeds a minimum
- * length, sending the user to Special:MWAssistant pre-filled with their
- * query. The button is intentionally scoped to MediaWiki's known search
- * forms so it never overlaps unrelated text inputs on the page.
+ * Renders a small icon button anchored inside the search input, vertically
+ * centered at its right edge. Clicking it sends the user's current query
+ * to Special:MWAssistant. The previous "Ask Assistant" pill below the input
+ * was getting hidden by the search-suggestion dropdown — placing the icon
+ * inside the input keeps it visible while suggestions are open.
  */
 (function (mw, $) {
     'use strict';
 
-    var MIN_LENGTH = 10;
-    var BUTTON_CLASS = 'mwassistant-search-btn';
+    var BUTTON_CLASS = 'mwassistant-search-icon-btn';
     var ATTACHED_FLAG = 'mwassistantAttached';
+
+    // Only show once the input looks like a question, not a keyword lookup.
+    // Roughly: longer than a single English word so it fires on phrases like
+    // "where are the labs" but stays hidden for "physics" or "main page".
+    var MIN_LENGTH = 12;
 
     // Limit ourselves to MediaWiki's actual search forms. Skins like Vector
     // 2022 may render the header search via Vue, so we use event delegation
@@ -26,24 +31,35 @@
 
     var INPUT_DELEGATE_SELECTOR = 'input[name="search"], input[type="search"], #searchInput';
 
+    // Inline SVG so we don't depend on an icon font; "sparkles" glyph reads
+    // as "AI / magic" across cultures and stays legible at 16px.
+    var ICON_SVG = (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" ' +
+            'width="16" height="16" aria-hidden="true" focusable="false">' +
+            '<path fill="currentColor" d="M10 1.5l1.6 4.4 4.4 1.6-4.4 1.6L10 13.5 8.4 9.1 4 7.5l4.4-1.6L10 1.5zM4.5 12l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8.8-2.2zM15.5 11l.6 1.6 1.6.6-1.6.6-.6 1.6-.6-1.6-1.6-.6 1.6-.6.6-1.6z"/>' +
+        '</svg>'
+    );
+
     function buildButton($input) {
+        var title = mw.msg('mwassistant-search-icon-title');
+        var label = mw.msg('mwassistant-search-icon-label');
         return $('<button>')
-            .addClass(BUTTON_CLASS + ' mw-ui-button mw-ui-quiet')
+            .addClass(BUTTON_CLASS)
             .attr({
                 type: 'button',
-                title: 'Ask the AI Assistant about this query'
+                title: title,
+                'aria-label': label
             })
-            .text('Ask Assistant')
+            .html(ICON_SVG)
             .hide()
             .on('click', function (e) {
                 e.preventDefault();
                 e.stopPropagation();
-                var query = $input.val();
-                if (!query) {
-                    return;
-                }
+                var query = $input.val() || '';
                 var url = mw.util.getUrl('Special:MWAssistant');
-                url += (url.indexOf('?') > -1 ? '&' : '?') + 'q=' + encodeURIComponent(query);
+                if (query) {
+                    url += (url.indexOf('?') > -1 ? '&' : '?') + 'q=' + encodeURIComponent(query);
+                }
                 window.location.href = url;
             });
     }
@@ -58,24 +74,30 @@
         return $btn;
     }
 
-    $(document).on('input.mwassistant keyup.mwassistant focus.mwassistant', INPUT_DELEGATE_SELECTOR, function () {
-        var $input = $(this);
-
-        // Only attach inside known MediaWiki search forms.
-        if (!$input.closest(SEARCH_FORM_SELECTORS).length) {
-            return;
-        }
-
-        var $btn = attachButton($input);
-        var val = $input.val() || '';
-
+    function syncVisibility($input, $btn) {
+        var val = ($input.val() || '').trim();
         if (val.length >= MIN_LENGTH) {
             if ($btn.is(':hidden')) {
-                $btn.fadeIn(150);
+                $btn.fadeIn(120);
             }
         } else if ($btn.is(':visible')) {
-            $btn.fadeOut(150);
+            $btn.fadeOut(120);
         }
-    });
+    }
+
+    // Attach + sync visibility on input / focus. Event delegation is necessary
+    // because Vector 2022 mounts the search box via Vue after DOM ready.
+    $(document).on(
+        'input.mwassistant focus.mwassistant keyup.mwassistant',
+        INPUT_DELEGATE_SELECTOR,
+        function () {
+            var $input = $(this);
+            if (!$input.closest(SEARCH_FORM_SELECTORS).length) {
+                return;
+            }
+            var $btn = attachButton($input);
+            syncVisibility($input, $btn);
+        }
+    );
 
 }(mediaWiki, jQuery));

--- a/resources/mwassistant.global.js
+++ b/resources/mwassistant.global.js
@@ -87,8 +87,10 @@
 
     // Attach + sync visibility on input / focus. Event delegation is necessary
     // because Vector 2022 mounts the search box via Vue after DOM ready.
+    // 'input' fires on every keystroke (including paste / IME), so we don't
+    // also need 'keyup'.
     $(document).on(
-        'input.mwassistant focus.mwassistant keyup.mwassistant',
+        'input.mwassistant focus.mwassistant',
         INPUT_DELEGATE_SELECTOR,
         function () {
             var $input = $(this);


### PR DESCRIPTION
## Summary
- **JobQueue refactor.** Auto-embed hooks and bulk dashboard updates now enqueue `UpdateEmbeddingJob` / `DeleteEmbeddingJob` instead of calling MCP synchronously. Page saves no longer block on MCP latency, the batch update is no longer bounded by `max_execution_time`, and brief MCP outages retry with backoff instead of dropping work. New `PageMoveComplete` hook drops the old title and re-embeds the new one (fixes rename orphans).
- **rev_id tracking on the wiki side.** `EmbeddingsClient::updatePage()` forwards `rev_id`; the dashboard's `pageIsOutdated` comparator prefers exact rev_id equality and falls back to `rev_timestamp` for legacy rows — never `page_touched`. Net effect: the synced/outdated counts are now correct.
- **Configurable namespace policy.** `$wgMWAssistantEmbedSkipNamespaces` (default `[NS_USER]`) and `$wgMWAssistantEmbedTalkPages` (default `false`) replace the hardcoded skip rules so research wikis using user pages for content can opt them in.
- **Smart retry classification.** 4xx other than 429 is treated as permanent (logged at ERROR, job dropped) so retries don't grind on requests that will keep failing. 5xx / 429 / transport errors are transient (WARNING, retry with backoff).
- **HttpClient fix.** Read `getStatus()`/`getContent()` unconditionally so 4xx/5xx response bodies (e.g. FastAPI 422 validation detail) aren't collapsed into "Transport error" — discovered while debugging the `extra_forbidden` rejection during rev_id rollout.
- **Search-bar UI.** Replaced the "Ask Assistant" pill below the search input (covered by the suggestion dropdown) with a small inline-SVG sparkles icon anchored inside the input; gated to inputs ≥ 12 chars so it appears for question-shaped queries.
- **i18n + branding.** Three special pages now drive their listing labels and titles from message keys; all user-visible "AI Assistant" strings renamed to "MW Assistant" (canonical names unchanged so URLs and permission keys keep working). New `i18n/qqq.json` documents every key.
- **Dashboard banner.** Static "Reload to see progress" link after batch enqueue (no auto-refresh).
- **Simplify pass:** `EmbeddingJobBase` abstract parent collapses ~60 lines of duplication between the two job classes; `Config::SYSTEM_USER_NAME` constant; per-request `getStats()` memo so submit + render don't double-call MCP; dropped the redundant `keyup` JS handler.

## Test plan
- [ ] `Special:SpecialPages` shows MW Assistant, MW Assistant: Embeddings, MW Assistant chat stream under the **Labki** group.
- [ ] Search-bar icon appears once you type ≥ 12 chars; click navigates to `Special:MWAssistant?q=...` and never gets covered by autocomplete.
- [ ] Save a page in an embedded namespace; saving completes instantly. `php maintenance/showJobs.php --group | grep mwassistant` shows a queued `mwassistantUpdateEmbedding`.
- [ ] Run `php maintenance/runJobs.php`; the dashboard's namespace counts move from outdated → synced after a reload.
- [ ] Move a page; both a `mwassistantDeleteEmbedding` (old title) and `mwassistantUpdateEmbedding` (new title) appear in the queue.
- [ ] Set `$wgMWAssistantEmbedTalkPages = true;` → talk-page saves now enqueue jobs.
- [ ] Set `$wgMWAssistantEmbedSkipNamespaces = [];` → user-page saves now enqueue jobs.

## Companion PR
Pairs with [labki-org/mw-mcp-server#TBD](https://github.com/labki-org/mw-mcp-server/pulls) — both should ship together since the rev_id and content_sha1 columns need to exist server-side before the wiki starts sending those fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)