### PR TITLE
tests: stabilize local wiki session config (fixes intermittent logout)

### DIFF
--- a/tests/LocalSettings.test.php
+++ b/tests/LocalSettings.test.php
@@ -5,6 +5,26 @@ wfLoadExtension( 'MWAssistant', '/mw-user-extensions/MWAssistant/extension.json'
 wfLoadExtension( 'Lockdown' );
 
 
+// Stable secret key for session-cookie signing. Without this MW falls back
+// to a per-process derivation; signed session cookies then fail validation
+// across requests. Local-test value only — never reuse in production.
+$wgSecretKey = 'mwassistant-local-dev-secret-key-DO-NOT-REUSE-7f3a9c2b1e4d6f8a';
+
+// Pin sessions to the database. The base image leaves wgSessionCacheType at
+// CACHE_ANYTHING, which falls through to wgMainCacheType=CACHE_ACCEL (APCu).
+// APCu is per Apache worker process, so a request landing on a different
+// worker than the one that stored the session can't find it and silently
+// logs the user out. Sending sessions through SqlBagOStuff keeps them
+// shared across workers and persistent across container restarts.
+$wgSessionCacheType = CACHE_DB;
+
+// Cookies don't differentiate by port, so any other labki-platform wiki
+// running on localhost (e.g. the base image's own compose-wiki) would
+// stomp on these cookies if we shared the default 'labki' prefix. Pick a
+// distinct prefix so the two test stacks coexist without logging each
+// other's sessions out.
+$wgCookiePrefix = 'mwassistant';
+
 // Secrets from old setup
 $wgMWAssistantJWTMWToMCPSecret = '8n7yHEg3UttL-lEOKASg-dS_xkU0gTuqGLn7zvhg4Uh-x52rtA0Zh13WJmGd8ojDjxXJB7qR9U';
 $wgMWAssistantJWTMCPToMWSecret = 'rgz5g_b6NPUlBUeZlir9XWNvnEcuOSq8bA1w2N6DUvCJROKIJKXRkyKdyPbKRio-3yh4RsHnvYQgApyYp7HEAs1Thc32wK';


### PR DESCRIPTION
## Summary

Fixes three independent issues that all manifest as "logged out every minute or so" in the local docker test wiki:

- **Set `\$wgSecretKey`** to a stable value. When unset, MW derives a fresh one per process; signed session cookies then fail validation as soon as a different Apache worker handles a request. Value here is obviously local-dev only.
- **Pin `\$wgSessionCacheType` to `CACHE_DB`.** The base image leaves it at `CACHE_ANYTHING`, which falls through to `wgMainCacheType = CACHE_ACCEL` (APCu). APCu is per Apache worker process — sessions stored by one worker are invisible to the rest. `SqlBagOStuff` keeps them shared across workers and persistent across container restarts.
- **Set `\$wgCookiePrefix = 'mwassistant'`.** Cookies don't differentiate by port, so running this wiki alongside the labki-platform base image's own `compose-wiki` on `localhost` meant both wrote `labki*` cookies to the same browser jar and stomped each other's sessions. Distinct prefixes let the two stacks coexist.

## Test plan

- [ ] `docker compose up -d --force-recreate wiki`
- [ ] In a fresh browser profile (or after clearing cookies for `localhost:8890`), log in.
- [ ] Click around for several minutes — session sticks.
- [ ] Run the labki-platform compose stack on `:8080` simultaneously, log into both — neither logs the other out.
- [ ] Confirm `wgSessionCacheType=1` (CACHE_DB), `wgCookiePrefix='mwassistant'`, `strlen(wgSecretKey)>=32` via the maintenance shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)