### PR TITLE
Render Markdown structure (lists, headings, paragraphs) in chat

### DIFF
--- a/resources/mwassistant.chat.css
+++ b/resources/mwassistant.chat.css
@@ -319,6 +319,64 @@
     font-size: 0.9em;
 }
 
+/* Markdown block elements rendered inside assistant messages. */
+.mwassistant-msg p {
+    margin: 0 0 8px 0;
+}
+
+.mwassistant-msg p:last-child {
+    margin-bottom: 0;
+}
+
+.mwassistant-md-list {
+    margin: 4px 0 8px 0;
+    padding-left: 24px;
+}
+
+.mwassistant-md-list li {
+    margin: 2px 0;
+    line-height: 1.5;
+}
+
+.mwassistant-md-list li > p:first-child {
+    display: inline;
+}
+
+.mwassistant-msg h1.mwassistant-md-h1,
+.mwassistant-msg h2.mwassistant-md-h2,
+.mwassistant-msg h3.mwassistant-md-h3,
+.mwassistant-msg h4.mwassistant-md-h4,
+.mwassistant-msg h5.mwassistant-md-h5,
+.mwassistant-msg h6.mwassistant-md-h6 {
+    margin: 12px 0 6px 0;
+    font-weight: 600;
+    line-height: 1.3;
+    color: #1f1f1f;
+    border: none;
+    padding: 0;
+}
+
+.mwassistant-msg h1.mwassistant-md-h1 { font-size: 1.3em; }
+.mwassistant-msg h2.mwassistant-md-h2 { font-size: 1.2em; }
+.mwassistant-msg h3.mwassistant-md-h3 { font-size: 1.1em; }
+.mwassistant-msg h4.mwassistant-md-h4,
+.mwassistant-msg h5.mwassistant-md-h5,
+.mwassistant-msg h6.mwassistant-md-h6 { font-size: 1em; }
+
+.mwassistant-msg h1.mwassistant-md-h1:first-child,
+.mwassistant-msg h2.mwassistant-md-h2:first-child,
+.mwassistant-msg h3.mwassistant-md-h3:first-child {
+    margin-top: 0;
+}
+
+.mwassistant-md-blockquote {
+    margin: 6px 0;
+    padding: 4px 12px;
+    border-left: 3px solid #c8ccd1;
+    color: #5f6368;
+    background-color: rgba(0, 0, 0, 0.02);
+}
+
 /* Tool Messages */
 .mwassistant-msg-tool {
     background: none;

--- a/resources/mwassistant.chat.js
+++ b/resources/mwassistant.chat.js
@@ -252,46 +252,177 @@
 
         /* ------------------------------------------------------------------
          * Markdown Parser (Safe)
+         *
+         * Two-pass: block-level structure (paragraphs, headings, lists,
+         * blockquotes, fenced code) is built from the raw line stream;
+         * inline structure (code, bold, italic, links, wikilinks) runs on
+         * each text segment after HTML-escaping. Doing block detection on
+         * raw text means we never have to un-escape anything to spot a
+         * `## heading` or a `1.` list marker, and HTML in user/LLM text is
+         * still escaped before being inserted into the DOM.
          * ------------------------------------------------------------------ */
 
         parseMarkdown(raw) {
             if (!raw) return "";
 
-            // Escape HTML – prevents XSS entirely.
-            let clean = this.escapeHtml(raw);
-
+            // Pull fenced code blocks out first so their contents never get
+            // mistaken for headings / lists / paragraphs. We store the raw
+            // code and escape it at render time.
             const codeBlocks = [];
-
-            // Extract fenced blocks
-            clean = clean.replace(/```([\s\S]*?)```/g, (match, code) => {
+            const stashed = raw.replace(/```([\s\S]*?)```/g, (_, code) => {
                 const index = codeBlocks.length;
-                codeBlocks.push(`
-                    <div class="mwassistant-code-wrapper">
-                        <button class="mwassistant-copy-btn" title="Copy code">Copy</button>
-                        <pre class="mwassistant-code-block"><code>${code.trim()}</code></pre>
-                    </div>
-                `);
-                return `___MWASSISTANT_CODE_BLOCK_${index}___`;
+                codeBlocks.push(code.replace(/^\n+|\n+$/g, ''));
+                return `\n CODE_BLOCK_${index} \n`;
             });
 
-            // Inline code (content already HTML-escaped above)
+            const lines = stashed.split('\n');
+            const out = [];
+            let i = 0;
+
+            const isCodePlaceholder = (s) => /^ CODE_BLOCK_(\d+) $/.test(s.trim());
+            const isHeading = (s) => /^#{1,6}\s+\S/.test(s);
+            const isOrdered = (s) => /^\s*\d+\.\s+\S/.test(s);
+            const isBullet = (s) => /^\s*[-*+]\s+\S/.test(s);
+            const isQuote = (s) => /^>\s?/.test(s);
+
+            while (i < lines.length) {
+                const line = lines[i];
+                const trimmed = line.trim();
+
+                // Blank line – just a separator between blocks.
+                if (!trimmed) { i++; continue; }
+
+                // Fenced code block.
+                const cm = trimmed.match(/^ CODE_BLOCK_(\d+) $/);
+                if (cm) {
+                    const code = this.escapeHtml(codeBlocks[parseInt(cm[1], 10)]);
+                    out.push(
+                        '<div class="mwassistant-code-wrapper">' +
+                            '<button class="mwassistant-copy-btn" title="Copy code">Copy</button>' +
+                            `<pre class="mwassistant-code-block"><code>${code}</code></pre>` +
+                        '</div>'
+                    );
+                    i++;
+                    continue;
+                }
+
+                // ATX heading.
+                const hm = trimmed.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+                if (hm) {
+                    const level = hm[1].length;
+                    out.push(`<h${level} class="mwassistant-md-h${level}">${this.renderInline(hm[2])}</h${level}>`);
+                    i++;
+                    continue;
+                }
+
+                // Ordered list — consume consecutive `N.` lines. Allow a
+                // single blank line between items (CommonMark "loose list").
+                if (isOrdered(line)) {
+                    const items = [];
+                    while (i < lines.length) {
+                        if (isOrdered(lines[i])) {
+                            const text = lines[i].replace(/^\s*\d+\.\s+/, '');
+                            items.push(`<li>${this.renderInline(text)}</li>`);
+                            i++;
+                        } else if (lines[i].trim() === '' && isOrdered(lines[i + 1] || '')) {
+                            i++;
+                        } else {
+                            break;
+                        }
+                    }
+                    out.push(`<ol class="mwassistant-md-list">${items.join('')}</ol>`);
+                    continue;
+                }
+
+                // Unordered list — same loose-list handling.
+                if (isBullet(line)) {
+                    const items = [];
+                    while (i < lines.length) {
+                        if (isBullet(lines[i])) {
+                            const text = lines[i].replace(/^\s*[-*+]\s+/, '');
+                            items.push(`<li>${this.renderInline(text)}</li>`);
+                            i++;
+                        } else if (lines[i].trim() === '' && isBullet(lines[i + 1] || '')) {
+                            i++;
+                        } else {
+                            break;
+                        }
+                    }
+                    out.push(`<ul class="mwassistant-md-list">${items.join('')}</ul>`);
+                    continue;
+                }
+
+                // Blockquote — accumulate consecutive `> ` lines.
+                if (isQuote(line)) {
+                    const buf = [];
+                    while (i < lines.length && isQuote(lines[i])) {
+                        buf.push(lines[i].replace(/^>\s?/, ''));
+                        i++;
+                    }
+                    out.push(`<blockquote class="mwassistant-md-blockquote">${this.renderInline(buf.join(' '))}</blockquote>`);
+                    continue;
+                }
+
+                // Paragraph: collect consecutive non-special lines. Single
+                // newlines inside a paragraph become a single space; blank
+                // lines start a new paragraph (CommonMark behavior).
+                const buf = [];
+                while (i < lines.length) {
+                    const l = lines[i];
+                    const t = l.trim();
+                    if (!t) break;
+                    if (isCodePlaceholder(t) || isHeading(l) || isOrdered(l) || isBullet(l) || isQuote(l)) break;
+                    buf.push(t);
+                    i++;
+                }
+                if (buf.length) {
+                    out.push(`<p>${this.renderInline(buf.join(' '))}</p>`);
+                }
+            }
+
+            return out.join('');
+        }
+
+        /**
+         * Run inline markdown transforms on a raw text segment. Order
+         * matters: escape HTML first so the patterns below operate on
+         * trusted text, then inline code (so its contents are not further
+         * mutated), then bold, italic, and the two link forms last.
+         */
+        renderInline(raw) {
+            let clean = this.escapeHtml(raw);
+
+            // Inline code – content is already escaped, safe to wrap.
             clean = clean.replace(/`([^`]+)`/g, (_, txt) => {
                 return `<code class="mwassistant-inline-code">${txt}</code>`;
             });
 
-            // Bold
-            clean = clean.replace(/\*\*([^*]+)\*\*/g, "<b>$1</b>");
+            // Bold (** ... **) – run before italic so it wins the `*` tokens.
+            clean = clean.replace(/\*\*([^*]+?)\*\*/g, "<b>$1</b>");
+
+            // Italic (* ... * or _ ... _) – avoid eating `**` leftovers and
+            // intra-word underscores like `foo_bar_baz`.
+            clean = clean.replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1<i>$2</i>");
+            clean = clean.replace(/(^|[\s(])_([^_\s][^_]*?)_(?![A-Za-z0-9])/g, "$1<i>$2</i>");
 
             // Markdown links — only allow safe URL schemes to prevent
             // javascript:/data: injection through model output.
             clean = clean.replace(
-                /\[([^\]]+)\]\(([^)]+)\)/g,
+                /\[([^\]]+)\]\(([^)\s]+)\)/g,
                 (match, label, url) => {
                     if (!this.isSafeUrl(url)) {
                         return match;
                     }
                     return `<a href="${url}" target="_blank" rel="noopener">${label}</a>`;
                 }
+            );
+
+            // Bare URLs – auto-link http(s) URLs that aren't already in an
+            // anchor or markdown link. The LLM frequently emits plain URLs
+            // and they should be clickable too.
+            clean = clean.replace(
+                /(^|[\s(])(https?:\/\/[^\s<)]+[^\s<).,;:!?'"])/g,
+                (_, lead, url) => `${lead}<a href="${url}" target="_blank" rel="noopener">${url}</a>`
             );
 
             // Wiki links – page comes from already-escaped text so it is safe
@@ -307,11 +438,6 @@
                     return `<a href="${url}" title="${this.escapeHtml(target)}">${label || target}</a>`;
                 }
             );
-
-            // Restore code blocks
-            clean = clean.replace(/___MWASSISTANT_CODE_BLOCK_(\d+)___/g, (_, idx) => {
-                return codeBlocks[parseInt(idx, 10)];
-            });
 
             return clean;
         }


### PR DESCRIPTION
## Summary
- Assistant chat responses were collapsing into single-block walls of text because `parseMarkdown` only handled inline patterns (bold, code, links) — block-level Markdown (paragraphs, numbered/bulleted lists, headings, blockquotes) had no effect once newlines were inserted into the DOM via `.html()`.
- Rewrote `parseMarkdown` as a two-pass renderer: a block pass that walks the line stream and emits `<p>`, `<ol>`/`<ul>` (with loose-list support so a blank line between items doesn't break the list), `<h1>`–`<h6>`, `<blockquote>`, and fenced `<pre>` blocks, plus a new `renderInline` that escapes HTML and applies inline code, bold, italic, markdown links, bare-URL autolinking, and `[[wikilinks]]`.
- Added CSS for the new block elements inside `.mwassistant-msg` so list indentation, heading sizes, and paragraph spacing match the existing chat aesthetic.

XSS posture is unchanged: every text segment is HTML-escaped before any inline pattern runs, and the markdown-link URL still goes through the `isSafeUrl` allowlist.

## Test plan
- [x] Hard-refresh `Special:MWAssistant` and confirm a numbered-list response (e.g. "list the projects on this wiki") renders as a real `<ol>` with one item per line.
- [x] Ask a question whose answer mentions multiple wiki pages — confirm `[[Page]]` references render as clickable wiki links and that bare `https://...` URLs in answers are also clickable.
- [x] Confirm fenced code blocks still render with the copy button and `<pre>` styling.
- [x] Verify the editor-sidebar chat (which reuses `mw.mwAssistant.Chat`) renders the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)